### PR TITLE
added setup.py files for catkin to set the PYTHONPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.py[cod]
 
 # C extensions

--- a/robotiq_c_model_control/CMakeLists.txt
+++ b/robotiq_c_model_control/CMakeLists.txt
@@ -18,6 +18,8 @@ add_message_files(
   CModel_robot_output.msg
 )
 
+catkin_python_setup()
+
 generate_messages()
 
 ###################################

--- a/robotiq_c_model_control/setup.py
+++ b/robotiq_c_model_control/setup.py
@@ -1,0 +1,13 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['robotiq_c_model_control'],
+    package_dir={'': 'src'},
+    requires=['rospy']
+)
+
+setup(**setup_args)

--- a/robotiq_modbus_tcp/CMakeLists.txt
+++ b/robotiq_modbus_tcp/CMakeLists.txt
@@ -8,6 +8,7 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 #set the default path for built libraries to the "lib" directory
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
+catkin_python_setup()
 
 ###################################
 ## catkin specific configuration ##

--- a/robotiq_modbus_tcp/setup.py
+++ b/robotiq_modbus_tcp/setup.py
@@ -1,0 +1,13 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['robotiq_modbus_tcp'],
+    package_dir={'': 'src'},
+    requires=['rospy', 'python-pymodbus']
+)
+
+setup(**setup_args)

--- a/robotiq_s_model_control/CMakeLists.txt
+++ b/robotiq_s_model_control/CMakeLists.txt
@@ -17,6 +17,8 @@ add_message_files(
   SModel_robot_output.msg
 )
 
+catkin_python_setup()
+
 generate_messages()
 
 ###################################

--- a/robotiq_s_model_control/setup.py
+++ b/robotiq_s_model_control/setup.py
@@ -1,0 +1,13 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['robotiq_s_model_control'],
+    package_dir={'': 'src'},
+    requires=['rospy']
+)
+
+setup(**setup_args)


### PR DESCRIPTION
added setup.py files in packages and catkin_python_setup in CMakeLists.txt

This allows catkin to setup correctly the PYTHONPATH so that nodes can import the python packages they need
