### PR TITLE
Fixed include tags and added inertial tags

### DIFF
--- a/robotiq_s_model_visualization/cfg/s-model_articulated.urdf
+++ b/robotiq_s_model_visualization/cfg/s-model_articulated.urdf
@@ -27,6 +27,11 @@ s-model_articulated - articulated version of the robotiq s-model,
         <color rgba="0 1 1 1"/>
       </material>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.01" ixy="-0.00002" ixz="0.00001" iyy="0.0008" iyz="0" izz="0.001"/>
+    </inertial>
   </link>
   <link name="finger_1_link_1">
     <visual>
@@ -43,6 +48,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.15"/>
+      <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024"/>
+    </inertial>
   </link>
   <link name="finger_1_link_2">
     <!--
@@ -64,6 +74,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.15"/>
+      <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024"/>
+    </inertial>
   </link>
   <link name="finger_1_link_3">
     <visual>
@@ -80,6 +95,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.001239" ixy="-0.000251" ixz="0.000019" iyy="0.00085" iyz="0" izz="0.001632"/>
+    </inertial>
   </link>
   <joint name="finger_1_joint_1" type="revolute">
     <parent link="finger_1_link_0"/>
@@ -121,6 +141,11 @@ s-model_articulated - articulated version of the robotiq s-model,
         <color rgba="0 1 1 1"/>
       </material>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.01" ixy="-0.00002" ixz="0.00001" iyy="0.0008" iyz="0" izz="0.001"/>
+    </inertial>
   </link>
   <link name="finger_2_link_1">
     <visual>
@@ -137,6 +162,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.15"/>
+      <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024"/>
+    </inertial>
   </link>
   <link name="finger_2_link_2">
     <!--
@@ -158,6 +188,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.15"/>
+      <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024"/>
+    </inertial>
   </link>
   <link name="finger_2_link_3">
     <visual>
@@ -174,6 +209,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.001239" ixy="-0.000251" ixz="0.000019" iyy="0.00085" iyz="0" izz="0.001632"/>
+    </inertial>
   </link>
   <joint name="finger_2_joint_1" type="revolute">
     <parent link="finger_2_link_0"/>
@@ -215,6 +255,11 @@ s-model_articulated - articulated version of the robotiq s-model,
         <color rgba="0 1 1 1"/>
       </material>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.01" ixy="-0.00002" ixz="0.00001" iyy="0.0008" iyz="0" izz="0.001"/>
+    </inertial>
   </link>
   <link name="finger_middle_link_1">
     <visual>
@@ -231,6 +276,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.15"/>
+      <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024"/>
+    </inertial>
   </link>
   <link name="finger_middle_link_2">
     <!--
@@ -252,6 +302,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.15"/>
+      <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024"/>
+    </inertial>
   </link>
   <link name="finger_middle_link_3">
     <visual>
@@ -268,6 +323,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </geometry>
       <material name="yellow"/>
     </collision>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.05"/>
+      <inertia ixx="0.001239" ixy="-0.000251" ixz="0.000019" iyy="0.00085" iyz="0" izz="0.001632"/>
+    </inertial>
   </link>
   <joint name="finger_middle_joint_1" type="revolute">
     <parent link="finger_middle_link_0"/>
@@ -308,6 +368,11 @@ s-model_articulated - articulated version of the robotiq s-model,
       </material>
     </collision>
   </link>
+  <inertial>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <mass value="1.3"/>
+    <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435"/>
+  </inertial>
   <joint name="palm_finger_1_joint" type="revolute">
     <parent link="palm"/>
     <child link="finger_1_link_0"/>
@@ -333,4 +398,3 @@ s-model_articulated - articulated version of the robotiq s-model,
 	<xacro:s-model_finger_articulated prefix=""/>
 -->
 </robot>
-

--- a/robotiq_s_model_visualization/cfg/s-model_articulated.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_articulated.xacro
@@ -6,7 +6,7 @@ s-model_articulated - articulated version of the robotiq s-model,
 -->
 <robot name="s-model_articulated" xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<include filename="$(find robotiq_s_model_visualization)/cfg/s-model_articulated_macro.xacro" />
+	<xacro:include filename="$(find robotiq_s_model_visualization)/cfg/s-model_articulated_macro.xacro" />
 	<xacro:s-model_articulated prefix=""/>
 
 <!--

--- a/robotiq_s_model_visualization/cfg/s-model_articulated_macro.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_articulated_macro.xacro
@@ -7,7 +7,7 @@ there are multiple hands then a prefix followed by an "_" is needed.
 
 -->
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-	<include filename="$(find robotiq_s_model_visualization)/cfg/s-model_finger_articulated_macro.xacro" />
+	<xacro:include filename="$(find robotiq_s_model_visualization)/cfg/s-model_finger_articulated_macro.xacro" />
 	<xacro:macro name="s-model_articulated" params="prefix">
 	<xacro:s-model_finger_articulated prefix="${prefix}finger_1_"/>
 	<xacro:s-model_finger_articulated prefix="${prefix}finger_2_"/>
@@ -31,6 +31,12 @@ there are multiple hands then a prefix followed by an "_" is needed.
 				</material>
 			</collision>
 		</link>
+        
+        <inertial>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <mass value="1.3"/>
+            <inertia ixx="0.006012" ixy="0.000079" ixz="-0.00024" iyy="0.012892" iyz="0" izz="0.002435" />
+        </inertial>
 		<!-- end of link list -->
 		<!-- joint list -->
 

--- a/robotiq_s_model_visualization/cfg/s-model_finger_articulated_macro.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_finger_articulated_macro.xacro
@@ -28,6 +28,11 @@ finger(i.e. finger_1, etc...).
 					<color rgba="0 1 1 1"/>
 				</material>
 			</collision>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <mass value="0.05"/>
+                <inertia ixx="0.01" ixy="-0.00002" ixz="0.00001" iyy="0.0008" iyz="0" izz="0.001" />
+            </inertial>         
 		</link>
 		<link name="${prefix}link_1">
 			<visual>
@@ -44,6 +49,11 @@ finger(i.e. finger_1, etc...).
 				</geometry>
 				<material name="yellow"/>
 			</collision>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <mass value="0.15"/>
+                <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024" />
+            </inertial>
 		</link>
 		<link name="${prefix}link_2">
 			<!--
@@ -65,6 +75,11 @@ finger(i.e. finger_1, etc...).
 				</geometry>
 				<material name="yellow"/>
 			</collision>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <mass value="0.15"/>
+                <inertia ixx="0.001859" ixy="-0.000376" ixz="0.000028" iyy="0.012756" iyz="0" izz="0.0024" />
+            </inertial>
 		</link>
 		<link name="${prefix}link_3">
 			<visual>
@@ -81,6 +96,11 @@ finger(i.e. finger_1, etc...).
 				</geometry>
 				<material name="yellow"/>
 			</collision>
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <mass value="0.05"/>
+                <inertia ixx="0.001239" ixy="-0.000251" ixz="0.000019" iyy="0.00085" iyz="0" izz="0.001632" />
+            </inertial>
 		</link>
 
 		<!-- end of link list -->

--- a/robotiq_s_model_visualization/cfg/s-model_mesh.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_mesh.xacro
@@ -4,7 +4,7 @@
 <!-- IT INCLUDES ONLY FIXED JOINTS (WHICH ARE NOT PUBLISHED BY THE JOINT -->
 <!-- STATE PUBLISHER.                                                    -->
 <robot name="s-model_mesh" xmlns:xacro="http://ros.org/wiki/xacro">
-	<include filename="$(find robotiq_s_model_visualization)/cfg/s-model_mesh_macro.xacro" />
+	<xacro:include filename="$(find robotiq_s_model_visualization)/cfg/s-model_mesh_macro.xacro" />
 	<xacro:s-model_mesh prefix=""/>
 </robot>
 


### PR DESCRIPTION
We noticed two issues with the robotiq model:
1. In hydro, including other xacro files using <include> tag were deprecated. Changed all of these to xacro:include
2. Model could not be used in gazebo, since no inertial information was modeled. I added inertial information to all links of the articulated model, based on CAD models and some assumptions. 
