### PR TITLE
Robotiq Action Server

### DIFF
--- a/robotiq_action_server/CMakeLists.txt
+++ b/robotiq_action_server/CMakeLists.txt
@@ -21,6 +21,8 @@ include_directories(
   ${robotiq_action_server_INCLUDE_DIRS}
 )
 
+
+# The action server
 add_executable(robotiq_c_model_action_server_node
     src/robotiq_c_model_action_server_node.cpp
     src/robotiq_c_model_action_server.cpp
@@ -34,7 +36,27 @@ add_dependencies(robotiq_c_model_action_server_node
    ${catkin_LIBRARIES}
  )
 
-install(TARGETS robotiq_action_server_node
+ # The test server
+add_executable(robotiq_action_server_client_test
+  src/robotiq_action_server_client_test.cpp
+)
+
+add_dependencies(robotiq_action_server_client_test
+  robotiq_action_server_generate_messages_cpp
+  ${robotiq_action_server_EXPORTED_TARGETS})
+
+ target_link_libraries(robotiq_action_server_client_test
+   ${catkin_LIBRARIES}
+ )
+
+
+install(TARGETS robotiq_c_model_action_server_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
+
+ install(TARGETS robotiq_action_server_client_test
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/robotiq_action_server/CMakeLists.txt
+++ b/robotiq_action_server/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(robotiq_action_server)
+
+find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  actionlib_msgs
+  message_generation
+  robotiq_c_model_control
+  roscpp
+  control_msgs
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS actionlib actionlib_msgs robotiq_c_model_control roscpp
+)
+
+include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${robotiq_action_server_INCLUDE_DIRS}
+)
+
+add_executable(robotiq_c_model_action_server_node
+    src/robotiq_c_model_action_server_node.cpp
+    src/robotiq_c_model_action_server.cpp
+    include/robotiq_action_server/robotiq_c_model_action_server.h)
+
+add_dependencies(robotiq_c_model_action_server_node
+  robotiq_action_server_generate_messages_cpp
+  ${robotiq_action_server_EXPORTED_TARGETS})
+
+ target_link_libraries(robotiq_c_model_action_server_node
+   ${catkin_LIBRARIES}
+ )
+
+install(TARGETS robotiq_action_server_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
+
+install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+ )

--- a/robotiq_action_server/CMakeLists.txt
+++ b/robotiq_action_server/CMakeLists.txt
@@ -21,7 +21,6 @@ include_directories(
   ${robotiq_action_server_INCLUDE_DIRS}
 )
 
-
 # The action server
 add_executable(robotiq_c_model_action_server_node
     src/robotiq_c_model_action_server_node.cpp

--- a/robotiq_action_server/include/robotiq_action_server/robotiq_c_model_action_server.h
+++ b/robotiq_action_server/include/robotiq_action_server/robotiq_c_model_action_server.h
@@ -1,0 +1,85 @@
+/**
+ * ActionServer interface to the control_msgs/GripperCommand action
+ * for a Robotiq C-Model (2 finger) device
+ */
+
+#ifndef ROBOTIQ_C_MODEL_ACTION_SERVER_H
+#define ROBOTIQ_C_MODEL_ACTION_SERVER_H
+
+// STL
+#include <string>
+// ROS standard
+#include <ros/ros.h>
+#include <actionlib/server/simple_action_server.h>
+#include <control_msgs/GripperCommandAction.h>
+// Repo specific includes
+#include <robotiq_c_model_control/CModel_robot_input.h>
+#include <robotiq_c_model_control/CModel_robot_output.h>
+
+
+namespace robotiq_action_server
+{
+
+typedef robotiq_c_model_control::CModel_robot_input GripperInput;
+typedef robotiq_c_model_control::CModel_robot_output GripperOutput;
+
+typedef control_msgs::GripperCommandGoal GripperCommandGoal;
+typedef control_msgs::GripperCommandFeedback GripperCommandFeedback;
+typedef control_msgs::GripperCommandResult GripperCommandResult;
+
+/**
+ * @brief Structure containing the parameters necessary to translate
+ *        GripperCommand actions to register-based commands to a
+ *        particular gripper (and vice versa).
+ *
+ *        The min gap can be less than zero. This represents the case where the 
+ *        gripper fingers close and then push forward.
+ */
+struct CModelGripperParams
+{
+  double min_gap_; // meters
+  double max_gap_;
+  double min_effort_; // N / (Nm)
+  double max_effort_;
+};
+
+/**
+ * @brief The CModelGripperActionServer class. Takes as arguments the name of the gripper it is to command,
+ *        and a set of parameters that define the physical characteristics of the particular gripper.
+ *        
+ *        The name parameter controls what topics this server listens to. For a given name `grippername`, 
+ *        it listens for input and output messages on `grippername/input` and 
+ *        `grippername/output` respectively.
+ */
+class CModelGripperActionServer
+{
+public:
+  CModelGripperActionServer(const std::string& name, const CModelGripperParams& params);
+
+  // These functions are meant to be called by simple action server
+  void goalCB();
+  void preemptCB();
+  void analysisCB(const GripperInput::ConstPtr& msg);
+
+private:
+  void issueActivation();
+
+  ros::NodeHandle nh_;
+  actionlib::SimpleActionServer<control_msgs::GripperCommandAction> as_;
+
+  ros::Subscriber state_sub_; // Subs to grippers "input" topic
+  ros::Publisher goal_pub_; // Pubs to grippers "output" topic
+
+  GripperOutput goal_reg_state_; // Goal information in gripper-register form
+  GripperInput current_reg_state_; // State info in gripper-register form
+
+  /* Used to translate GripperCommands in engineering units
+   * to/from register states understood by gripper itself. Different
+   * for different models/generations of Robotiq grippers */
+  CModelGripperParams gripper_params_;
+
+  std::string action_name_;
+};
+
+}
+#endif

--- a/robotiq_action_server/include/robotiq_action_server/robotiq_c_model_action_server.h
+++ b/robotiq_action_server/include/robotiq_action_server/robotiq_c_model_action_server.h
@@ -47,9 +47,7 @@ struct CModelGripperParams
  * @brief The CModelGripperActionServer class. Takes as arguments the name of the gripper it is to command,
  *        and a set of parameters that define the physical characteristics of the particular gripper.
  *        
- *        The name parameter controls what topics this server listens to. For a given name `grippername`, 
- *        it listens for input and output messages on `grippername/input` and 
- *        `grippername/output` respectively.
+ *        Listens for messages on input and publishes on output. Remap these.
  */
 class CModelGripperActionServer
 {

--- a/robotiq_action_server/launch/robotiq_c_model_action_server.launch
+++ b/robotiq_action_server/launch/robotiq_c_model_action_server.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<launch>
+  <arg name="gripper_name" default="gripper" />
+  <arg name="min_gap" default="-0.017" />
+  <arg name="max_gap" default="0.085" /> <!-- meters -->
+  <arg name="min_effort" default="30.0" />
+  <arg name="max_effort" default="100.0" />
+
+  <node name="robotiq_c_model_action_server" pkg="robotiq_action_server" 
+    type="robotiq_c_model_action_server_node">
+    <param name="gripper_name" type="str" value="$(arg gripper_name)" />
+    <param name="min_gap" type="double" value="$(arg min_gap)" />
+    <param name="max_gap" type="double" value="$(arg max_gap)" />
+    <param name="min_effort" type="double" value="$(arg min_effort)" />
+    <param name="max_effort" type="double" value="$(arg max_effort)" />
+  </node>
+
+</launch>

--- a/robotiq_action_server/launch/robotiq_c_model_action_server.launch
+++ b/robotiq_action_server/launch/robotiq_c_model_action_server.launch
@@ -14,6 +14,9 @@
     <param name="max_gap" type="double" value="$(arg max_gap)" />
     <param name="min_effort" type="double" value="$(arg min_effort)" />
     <param name="max_effort" type="double" value="$(arg max_effort)" />
+
+    <remap from="input" to="$(arg gripper_name)/input" />
+    <remap from="output" to="$(arg gripper_name)/output" />
   </node>
 
 </launch>

--- a/robotiq_action_server/package.xml
+++ b/robotiq_action_server/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package>
+  <name>robotiq_action_server</name>
+  <version>0.1.0</version>
+
+  <description>
+    <p>
+      This package defines protocol-agnostic action-server interfaces using the 
+      control_msgs::GripperCommand ROS interface for Robotiq grippers. Depending
+      on your use case, you may need more fine grained control, but this is
+      a good place to start.
+    </p>
+  </description>
+
+  <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
+  <author>Jonathan Meyer</author>
+
+  <license>BSD</license>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>robotiq_c_model_control</build_depend>
+  <build_depend>roscpp</build_depend>
+
+  <run_depend>actionlib</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>robotiq_c_model_control</run_depend>
+  <run_depend>roscpp</run_depend>
+
+</package>

--- a/robotiq_action_server/src/robotiq_action_server_client_test.cpp
+++ b/robotiq_action_server/src/robotiq_action_server_client_test.cpp
@@ -1,0 +1,43 @@
+#include <ros/ros.h>
+#include <actionlib/client/simple_action_client.h>
+#include <actionlib/client/terminal_state.h>
+#include <control_msgs/GripperCommandAction.h>
+
+int main (int argc, char **argv)
+{
+  ros::init(argc, argv, "test_robotiq_action_server");
+
+  ros::NodeHandle pnh("~");
+
+  std::string gripper_name;
+  pnh.param<std::string>("gripper_name", gripper_name, "gripper");
+
+  // create the action client
+  // true causes the client to spin its own thread
+  actionlib::SimpleActionClient<control_msgs::GripperCommandAction> ac(gripper_name, true);
+
+  ROS_INFO("Waiting for action server to start.");
+  // wait for the action server to start
+  ac.waitForServer(); //will wait for infinite time
+
+  ROS_INFO("Action server started, sending goal.");
+  // send a goal to the action
+  control_msgs::GripperCommandGoal goal;
+  goal.command.position = -0.01;
+  goal.command.max_effort = 100.0;
+  ac.sendGoal(goal);
+
+  //wait for the action to return
+  bool finished_before_timeout = ac.waitForResult(ros::Duration(30.0));
+
+  if (finished_before_timeout)
+  {
+    actionlib::SimpleClientGoalState state = ac.getState();
+    ROS_INFO("Action finished: %s",state.toString().c_str());
+  }
+  else
+    ROS_INFO("Action did not finish before the time out.");
+
+  //exit
+  return 0;
+}

--- a/robotiq_action_server/src/robotiq_c_model_action_server.cpp
+++ b/robotiq_action_server/src/robotiq_c_model_action_server.cpp
@@ -1,0 +1,192 @@
+/**
+ * ActionServer interface to the control_msgs/GripperCommand action
+ * for a Robotiq C-Model device
+ */
+
+#include "robotiq_action_server/robotiq_c_model_action_server.h"
+
+// To keep the fully qualified names managable
+namespace ras = robotiq_action_server;
+
+//Anonymous namespaces are file local -> sort of like global static objects
+namespace
+{
+  using namespace ras;
+
+  /*  This struct is declared for the sole purpose of being used as an exception internally
+      to keep the code clean (i.e. no output params). It is caught by the action_server and 
+      should not propogate outwards. If you use these functions yourself, beware.
+  */
+  struct BadArgumentsError {};
+
+
+  GripperOutput goalToRegisterState(const GripperCommandGoal& goal, const CModelGripperParams& params)
+  {
+    GripperOutput result;
+    result.rACT = 0x1; // active gripper
+    result.rGTO = 0x1; // go to position
+    result.rATR = 0x0; // No emergency release
+    result.rSP = 128; // Middle ground speed
+    
+    if (goal.command.position > params.max_gap_ || goal.command.position < params.min_gap_)
+    {
+      ROS_WARN("Goal gripper gap size is out of range(%f to %f): %f m",
+               params.min_gap_, params.max_gap_, goal.command.position);
+      throw BadArgumentsError();
+    }
+    
+    if (goal.command.max_effort < params.min_effort_ || goal.command.max_effort > params.max_effort_)
+    {
+      ROS_WARN("Goal gripper effort out of range (%f to %f N): %f N",
+               params.min_effort_, params.max_effort_, goal.command.max_effort);
+      throw BadArgumentsError();
+    }
+
+    double dist_per_tick = (params.max_gap_ - params.min_gap_) / 255;
+    double eff_per_tick = (params.max_effort_ - params.min_effort_) / 255;
+
+    result.rPR = static_cast<uint8_t>((goal.command.position - params.min_gap_) / dist_per_tick);
+    result.rFR = static_cast<uint8_t>((goal.command.max_effort - params.min_effort_) / eff_per_tick);
+
+    return result;
+  }
+
+  /*  This function is templatized because both GripperCommandResult and GripperCommandFeedback consist
+      of the same fields yet have different types. Templates here act as a "duck typing" mechanism to avoid
+      code duplication.
+  */
+  template<typename T>
+  T registerStateToResultT(const GripperInput& input, const CModelGripperParams& params, uint8_t goal_pos)
+  {
+    T result;
+    double dist_per_tick = (params.max_gap_ - params.min_gap_) / 255;
+    double eff_per_tick = (params.max_effort_ - params.min_effort_) / 255;
+
+    result.position = input.gPO * dist_per_tick + params.min_gap_;
+    result.effort = input.gCU * eff_per_tick + params.min_effort_;
+    result.stalled = input.gOBJ == 0x1 || input.gOBJ == 0x2;
+    result.reached_goal = input.gPO == goal_pos;
+
+    return result;
+  }
+
+  // Inline api-transformers to avoid confusion when reading the action_server source
+  inline
+  GripperCommandResult registerStateToResult(const GripperInput& input, const CModelGripperParams& params, uint8_t goal_pos)
+  {
+    return registerStateToResultT<GripperCommandResult>(input, params, goal_pos);
+  }
+
+  inline
+  GripperCommandFeedback registerStateToFeedback(const GripperInput& input, const CModelGripperParams& params, uint8_t goal_pos)
+  {
+    return registerStateToResultT<GripperCommandFeedback>(input, params, goal_pos);
+  }
+
+} // end of anon namespace
+
+
+ras::CModelGripperActionServer::CModelGripperActionServer(const std::string& name, const CModelGripperParams& params)
+  : nh_()
+  , as_(nh_, name, false)
+  , action_name_(name)
+  , gripper_params_(params)
+{
+  as_.registerGoalCallback(boost::bind(&CModelGripperActionServer::goalCB, this));
+  as_.registerPreemptCallback(boost::bind(&CModelGripperActionServer::preemptCB, this));
+
+  state_sub_ = nh_.subscribe(name + "/input", 1, &CModelGripperActionServer::analysisCB, this);
+  goal_pub_ = nh_.advertise<GripperOutput>(name + "/output", 1);
+
+  as_.start();
+}
+
+void ras::CModelGripperActionServer::goalCB()
+{
+  // Check to see if the gripper is in an active state where it can take goals
+  if (current_reg_state_.gSTA != 0x3)
+  {
+    ROS_WARN("%s could not accept goal because the gripper is not yet active", action_name_.c_str());
+    return;
+  }
+
+  GripperCommandGoal current_goal (*(as_.acceptNewGoal()));
+
+  if (as_.isPreemptRequested())
+  {
+    as_.setPreempted();
+  }
+
+  try
+  {
+    goal_reg_state_ = goalToRegisterState(current_goal, gripper_params_);
+    goal_pub_.publish(goal_reg_state_);
+  }
+  catch (BadArgumentsError& e)
+  {
+    ROS_INFO("%s No goal issued to gripper", action_name_.c_str());
+  }
+}
+
+void ras::CModelGripperActionServer::preemptCB()
+{
+  ROS_INFO("%s: Preempted", action_name_.c_str());
+  as_.setPreempted();
+}
+
+void ras::CModelGripperActionServer::analysisCB(const GripperInput::ConstPtr& msg)
+{
+  current_reg_state_ = *msg;
+
+  if (!as_.isActive()) return;
+
+  // Check to see if the gripper is in its activated state
+  if (current_reg_state_.gSTA != 0x3)
+  {
+    // Check to see if the gripper is active or if it has been asked to be active
+    if (current_reg_state_.gSTA == 0x0 && goal_reg_state_.rACT != 0x1)
+    {
+      // If it hasn't been asked, active it
+      issueActivation();
+    }
+
+    // Otherwise wait for the gripper to activate
+    // TODO: If message delivery isn't guaranteed, then we may want to resend activate
+    return;
+  }
+
+  // Check for errors
+  if (current_reg_state_.gFLT)
+  {
+    ROS_WARN("%s faulted with code: %x", action_name_.c_str(), current_reg_state_.gFLT);
+    as_.setAborted(registerStateToResult<GripperCommandResult>(current_reg_state_,
+                                                               gripper_params_,
+                                                               goal_reg_state_.rPR));
+  }
+  else if (current_reg_state_.gGTO && current_reg_state_.gOBJ && current_reg_state_.gPR == goal_reg_state_.rPR)
+  {
+    // If commanded to move and if at a goal state and if the position request matches the echo'd PR, we're
+    // done with a move
+    ROS_INFO("%s succeeded", action_name_.c_str());
+    as_.setSucceeded(registerStateToResult<GripperCommandResult>(current_reg_state_,
+                                                                 gripper_params_,
+                                                                 goal_reg_state_.rPR));
+  }
+  else
+  {
+    // Publish feedback
+    as_.publishFeedback(registerStateToFeedback(current_reg_state_,
+                                                gripper_params_,
+                                                goal_reg_state_.rPR));
+  }
+}
+
+void ras::CModelGripperActionServer::issueActivation()
+{
+  ROS_INFO("Activating gripper for gripper action server: %s", action_name_.c_str());
+  GripperOutput out;
+  out.rACT = 0x1;
+  // other params should be zero
+  goal_reg_state_ = out;
+  goal_pub_.publish(out);
+}

--- a/robotiq_action_server/src/robotiq_c_model_action_server.cpp
+++ b/robotiq_action_server/src/robotiq_c_model_action_server.cpp
@@ -45,8 +45,10 @@ namespace
     double dist_per_tick = (params.max_gap_ - params.min_gap_) / 255;
     double eff_per_tick = (params.max_effort_ - params.min_effort_) / 255;
 
-    result.rPR = static_cast<uint8_t>((goal.command.position - params.min_gap_) / dist_per_tick);
+    result.rPR = static_cast<uint8_t>((params.max_gap_ - goal.command.position) / dist_per_tick);
     result.rFR = static_cast<uint8_t>((goal.command.max_effort - params.min_effort_) / eff_per_tick);
+
+    ROS_INFO("Setting goal position register to %hhu", result.rPR);
 
     return result;
   }
@@ -159,18 +161,18 @@ void ras::CModelGripperActionServer::analysisCB(const GripperInput::ConstPtr& ms
   if (current_reg_state_.gFLT)
   {
     ROS_WARN("%s faulted with code: %x", action_name_.c_str(), current_reg_state_.gFLT);
-    as_.setAborted(registerStateToResult<GripperCommandResult>(current_reg_state_,
-                                                               gripper_params_,
-                                                               goal_reg_state_.rPR));
+    as_.setAborted(registerStateToResult(current_reg_state_,
+                                         gripper_params_,
+                                         goal_reg_state_.rPR));
   }
   else if (current_reg_state_.gGTO && current_reg_state_.gOBJ && current_reg_state_.gPR == goal_reg_state_.rPR)
   {
     // If commanded to move and if at a goal state and if the position request matches the echo'd PR, we're
     // done with a move
     ROS_INFO("%s succeeded", action_name_.c_str());
-    as_.setSucceeded(registerStateToResult<GripperCommandResult>(current_reg_state_,
-                                                                 gripper_params_,
-                                                                 goal_reg_state_.rPR));
+    as_.setSucceeded(registerStateToResult(current_reg_state_,
+                                           gripper_params_,
+                                           goal_reg_state_.rPR));
   }
   else
   {

--- a/robotiq_action_server/src/robotiq_c_model_action_server.cpp
+++ b/robotiq_action_server/src/robotiq_c_model_action_server.cpp
@@ -6,12 +6,11 @@
 #include "robotiq_action_server/robotiq_c_model_action_server.h"
 
 // To keep the fully qualified names managable
-namespace ras = robotiq_action_server;
 
 //Anonymous namespaces are file local -> sort of like global static objects
 namespace
 {
-  using namespace ras;
+  using namespace robotiq_action_server;
 
   /*  This struct is declared for the sole purpose of being used as an exception internally
       to keep the code clean (i.e. no output params). It is caught by the action_server and 
@@ -87,8 +86,10 @@ namespace
 
 } // end of anon namespace
 
+namespace robotiq_action_server
+{
 
-ras::CModelGripperActionServer::CModelGripperActionServer(const std::string& name, const CModelGripperParams& params)
+CModelGripperActionServer::CModelGripperActionServer(const std::string& name, const CModelGripperParams& params)
   : nh_()
   , as_(nh_, name, false)
   , action_name_(name)
@@ -97,13 +98,13 @@ ras::CModelGripperActionServer::CModelGripperActionServer(const std::string& nam
   as_.registerGoalCallback(boost::bind(&CModelGripperActionServer::goalCB, this));
   as_.registerPreemptCallback(boost::bind(&CModelGripperActionServer::preemptCB, this));
 
-  state_sub_ = nh_.subscribe(name + "/input", 1, &CModelGripperActionServer::analysisCB, this);
-  goal_pub_ = nh_.advertise<GripperOutput>(name + "/output", 1);
+  state_sub_ = nh_.subscribe("input", 1, &CModelGripperActionServer::analysisCB, this);
+  goal_pub_ = nh_.advertise<GripperOutput>("output", 1);
 
   as_.start();
 }
 
-void ras::CModelGripperActionServer::goalCB()
+void CModelGripperActionServer::goalCB()
 {
   // Check to see if the gripper is in an active state where it can take goals
   if (current_reg_state_.gSTA != 0x3)
@@ -130,13 +131,13 @@ void ras::CModelGripperActionServer::goalCB()
   }
 }
 
-void ras::CModelGripperActionServer::preemptCB()
+void CModelGripperActionServer::preemptCB()
 {
   ROS_INFO("%s: Preempted", action_name_.c_str());
   as_.setPreempted();
 }
 
-void ras::CModelGripperActionServer::analysisCB(const GripperInput::ConstPtr& msg)
+void CModelGripperActionServer::analysisCB(const GripperInput::ConstPtr& msg)
 {
   current_reg_state_ = *msg;
 
@@ -183,7 +184,7 @@ void ras::CModelGripperActionServer::analysisCB(const GripperInput::ConstPtr& ms
   }
 }
 
-void ras::CModelGripperActionServer::issueActivation()
+void CModelGripperActionServer::issueActivation()
 {
   ROS_INFO("Activating gripper for gripper action server: %s", action_name_.c_str());
   GripperOutput out;
@@ -192,3 +193,4 @@ void ras::CModelGripperActionServer::issueActivation()
   goal_reg_state_ = out;
   goal_pub_.publish(out);
 }
+} // end robotiq_action_server namespace

--- a/robotiq_action_server/src/robotiq_c_model_action_server_node.cpp
+++ b/robotiq_action_server/src/robotiq_c_model_action_server_node.cpp
@@ -1,0 +1,45 @@
+#include "robotiq_action_server/robotiq_c_model_action_server.h"
+
+namespace
+{
+  // Defines a default for the c2 model 85 gripper
+  robotiq_action_server::CModelGripperParams c2_85_defaults()
+  {
+    robotiq_action_server::CModelGripperParams params;
+    params.min_gap_ = -.017;
+    params.max_gap_ = 0.085;
+    params.min_effort_ = 30.0; // This is a guess. Could not find data with quick search.
+    params.max_effort_ = 100.0;
+
+    return params;
+  }
+}
+
+int main(int argc, char** argv)
+{
+  // Can be renamed with standard ROS-node launch interface
+  ros::init(argc, argv, "gripper_action_server");
+  
+  // Private Note Handle for retrieving parameter arguments to the server
+  ros::NodeHandle private_nh("~");
+
+  std::string gripper_name;
+  private_nh.param<std::string>("gripper_name", gripper_name, "gripper");
+
+  // Fill out C-Model Params
+  robotiq_action_server::CModelGripperParams cparams = c2_85_defaults();
+  
+  // Min because fingers can push forward before the mechanical stops are reached
+  private_nh.param<double>("min_gap", cparams.min_gap_, cparams.min_gap_);
+  private_nh.param<double>("max_gap", cparams.max_gap_, cparams.max_gap_);
+  private_nh.param<double>("min_effort", cparams.min_effort_, cparams.min_effort_);
+  private_nh.param<double>("max_effort", cparams.max_effort_, cparams.max_effort_);
+
+  ROS_INFO("Initializing Robotiq action server for gripper: %s", gripper_name.c_str());
+
+  // The name of the gripper -> this server communicates over name/inputs and name/outputs
+  robotiq_action_server::CModelGripperActionServer gripper (gripper_name, cparams);
+
+  ROS_INFO("Robotiq action-server spinning for gripper: %s", gripper_name.c_str());
+  ros::spin();
+}

--- a/robotiq_action_server/src/robotiq_c_model_action_server_node.cpp
+++ b/robotiq_action_server/src/robotiq_c_model_action_server_node.cpp
@@ -8,7 +8,7 @@ namespace
     robotiq_action_server::CModelGripperParams params;
     params.min_gap_ = -.017;
     params.max_gap_ = 0.085;
-    params.min_effort_ = 30.0; // This is a guess. Could not find data with quick search.
+    params.min_effort_ = 40.0; // This is a guess. Could not find data with quick search.
     params.max_effort_ = 100.0;
 
     return params;


### PR DESCRIPTION
This request adds a simple_action_server which communicates with a named gripper using the control_msgs::GripperCommandAction type. 

The exact specification of your gripper can be defined in code or in the launch file. This includes min/max values for both gripper position and gripper effort. The robotiq accepts position requests in the form of an unsigned byte 0-255, however it closes prior to 255. After the fingers close, they push forward slightly. I chose to define min_position as having a negative number that corresponds to the gap size decreasing linearly past zero. If you don't like this, you can set your min gap to zero and the program will linearly interpolate the resulting command value accordingly.

The result object will report stalled if the gripper was not able to reach its position for any reason, including object detection. The GripperCommandAction interface doesn't allow for the more fine grained robotiq information.

Thanks for looking at this!
