### PR TITLE
Ethercat interface

### DIFF
--- a/robotiq_c_model_control/CMakeLists.txt
+++ b/robotiq_c_model_control/CMakeLists.txt
@@ -1,7 +1,7 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_c_model_control)
-find_package(catkin REQUIRED COMPONENTS rospy message_generation)
+find_package(catkin REQUIRED COMPONENTS robotiq_ethercat roscpp rospy message_generation)
 
 
 #set the default path for built executables to the "bin" directory
@@ -31,8 +31,28 @@ generate_messages()
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    CATKIN_DEPENDS rospy message_runtime
+    CATKIN_DEPENDS rospy message_runtime roscpp robotiq_ethercat
+    INCLUDE_DIRS include
 )
+
+include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${robotiq_ethercat_INCLUDE_DIRS}
+)
+
+add_executable(c_model_ethercat_node 
+  src/robotiq_c_model_control/c_model_ethercat_node.cpp 
+  src/robotiq_c_model_control/c_model_ethercat_client.cpp
+)
+
+target_link_libraries(c_model_ethercat_node
+   ${robotiq_ethercat_LIBRARIES}
+   ${catkin_LIBRARIES}
+  
+)
+
+add_dependencies(c_model_ethercat_node robotiq_c_model_control_generate_messages_cpp)
 
 #############
 ## Install ##

--- a/robotiq_c_model_control/include/robotiq_c_model_control/c_model_ethercat_client.h
+++ b/robotiq_c_model_control/include/robotiq_c_model_control/c_model_ethercat_client.h
@@ -1,0 +1,66 @@
+#ifndef C_MODEL_ETHERCAT_CLIENT_H
+#define C_MODEL_ETHERCAT_CLIENT_H
+
+#include <robotiq_c_model_control/CModel_robot_output.h>
+#include <robotiq_c_model_control/CModel_robot_input.h>
+
+// Forward declaration of EtherCatManager
+namespace robotiq_ethercat 
+{
+  class EtherCatManager;
+}
+
+namespace robotiq_c_model_control
+{
+
+/**
+ * \brief This class provides a client for the EtherCAT manager object that
+ *        can translate robot input/output messages and translate them to
+ *        the underlying IO Map.
+ */
+
+class CModelEtherCatClient
+{
+public:
+  typedef robotiq_c_model_control::CModel_robot_output GripperOutput;
+  typedef robotiq_c_model_control::CModel_robot_input GripperInput;
+
+  /**
+   * \brief Constructs a control interface to a C Model Robotiq gripper on
+   *        the given ethercat network and the given slave_no.
+   *
+   * @param[in] manager The interface to an EtherCAT network that the gripper
+   *                    is connected to.
+   *
+   * @param[in] slave_no The slave number of the gripper on the EtherCAT network
+   *                     (>= 1)
+   */
+  CModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, int slave_no);
+
+  /**
+   * \brief Write the given set of control flags to the memory of the gripper
+   * 
+   * @param[in] output The set of output-register values to write to the gripper
+   */
+  void writeOutputs(const GripperOutput& output);
+  
+  /**
+   * \brief Reads set of input-register values from the gripper.
+   * \return The gripper input registers as read from the controller IOMap
+   */
+  GripperInput readInputs() const;
+  
+  /**
+   * \brief Reads set of output-register values from the gripper.
+   * \return The gripper output registers as read from the controller IOMap
+   */
+  GripperOutput readOutputs() const;
+
+private:
+  robotiq_ethercat::EtherCatManager& manager_;
+  const int slave_no_;
+};
+
+}
+
+#endif

--- a/robotiq_c_model_control/launch/c_model_ethercat.launch
+++ b/robotiq_c_model_control/launch/c_model_ethercat.launch
@@ -1,6 +1,10 @@
 <launch>
+  <!-- Also optionally takes a gripper_name argument -->
   <node pkg="robotiq_c_model_control" type="c_model_ethercat_node" name="gripper_server" output="screen">
       <param name="ifname" value="eth2" type="str"/>
+      <param name="activate" type="bool" value="true" />
       <param name="slave_number" value="1" type="int"/>
+      <remap from="/CModelRobotOutput" to="/gripper/output" />
+      <remap from="/CModelRobotInput" to="/gripper/input" />
     </node>
 </launch>

--- a/robotiq_c_model_control/launch/c_model_ethercat.launch
+++ b/robotiq_c_model_control/launch/c_model_ethercat.launch
@@ -1,10 +1,15 @@
 <launch>
-  <!-- Also optionally takes a gripper_name argument -->
+  <arg name="gripper_name" default="gripper" />
+  <arg name="slave_number" default="1" />
+  <arg name="activate" default="True" />
+  <arg name="ifname" default="eth1" />
+
   <node pkg="robotiq_c_model_control" type="c_model_ethercat_node" name="gripper_server" output="screen">
-      <param name="ifname" value="eth2" type="str"/>
-      <param name="activate" type="bool" value="true" />
-      <param name="slave_number" value="1" type="int"/>
-      <remap from="/CModelRobotOutput" to="/gripper/output" />
-      <remap from="/CModelRobotInput" to="/gripper/input" />
+      <param name="ifname" type="str" value="$(arg ifname)" />
+      <param name="activate" type="bool" value="$(arg activate)" />
+      <param name="slave_number" type="int" value="$(arg slave_number)"/>
+      <!-- Remove these remaps to make the node compatible with the existing python scripts  -->
+      <remap from="/CModelRobotOutput" to="/$(arg gripper_name)/output" />
+      <remap from="/CModelRobotInput" to="/$(arg gripper_name)/input" />
     </node>
 </launch>

--- a/robotiq_c_model_control/launch/c_model_ethercat.launch
+++ b/robotiq_c_model_control/launch/c_model_ethercat.launch
@@ -1,0 +1,6 @@
+<launch>
+  <node pkg="robotiq_c_model_control" type="c_model_ethercat_node" name="gripper_server" output="screen">
+      <param name="ifname" value="eth2" type="str"/>
+      <param name="slave_number" value="1" type="int"/>
+    </node>
+</launch>

--- a/robotiq_c_model_control/launch/c_model_ethercat.launch
+++ b/robotiq_c_model_control/launch/c_model_ethercat.launch
@@ -8,8 +8,8 @@
       <param name="ifname" type="str" value="$(arg ifname)" />
       <param name="activate" type="bool" value="$(arg activate)" />
       <param name="slave_number" type="int" value="$(arg slave_number)"/>
-      <!-- Remove these remaps to make the node compatible with the existing python scripts  -->
-      <remap from="/CModelRobotOutput" to="/$(arg gripper_name)/output" />
-      <remap from="/CModelRobotInput" to="/$(arg gripper_name)/input" />
+      
+      <remap from="output" to="/$(arg gripper_name)/output" />
+      <remap from="input" to="/$(arg gripper_name)/input" />
     </node>
 </launch>

--- a/robotiq_c_model_control/package.xml
+++ b/robotiq_c_model_control/package.xml
@@ -9,9 +9,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>robotiq_ethercat</build_depend>
   <build_depend>message_generation</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>robotiq_ethercat</run_depend>
 
 
 

--- a/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_client.cpp
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_client.cpp
@@ -5,9 +5,10 @@
 // See Robotiq's documentation for the register mapping
 
 // An effort to keep the lines less than 100 char long
-namespace c_model = robotiq_c_model_control;
+namespace robotiq_c_model_control
+{
 
-c_model::CModelEtherCatClient::CModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, 
+CModelEtherCatClient::CModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, 
                                                     int slave_no)
   : manager_(manager)
   , slave_no_(slave_no)
@@ -16,7 +17,7 @@ c_model::CModelEtherCatClient::CModelEtherCatClient(robotiq_ethercat::EtherCatMa
 /*
   See support.robotiq.com -> manual for the register output meanings
 */
-void c_model::CModelEtherCatClient::writeOutputs(const GripperOutput& output)
+void CModelEtherCatClient::writeOutputs(const GripperOutput& output)
 {
   uint8_t map[6] = {0}; // array containing all 6 output registers
 
@@ -33,7 +34,7 @@ void c_model::CModelEtherCatClient::writeOutputs(const GripperOutput& output)
   }
 }
 
-c_model::CModelEtherCatClient::GripperInput c_model::CModelEtherCatClient::readInputs() const
+CModelEtherCatClient::GripperInput CModelEtherCatClient::readInputs() const
 {
   uint8_t map[6];
 
@@ -57,7 +58,7 @@ c_model::CModelEtherCatClient::GripperInput c_model::CModelEtherCatClient::readI
   return input;
 }
 
-c_model::CModelEtherCatClient::GripperOutput c_model::CModelEtherCatClient::readOutputs() const
+CModelEtherCatClient::GripperOutput CModelEtherCatClient::readOutputs() const
 {
   uint8_t map[6];
   for (unsigned i = 0; i < 6; ++i)
@@ -75,3 +76,4 @@ c_model::CModelEtherCatClient::GripperOutput c_model::CModelEtherCatClient::read
 
   return output;
 }
+} // end of robotiq_c_model_control namespace

--- a/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_client.cpp
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_client.cpp
@@ -1,0 +1,77 @@
+#include "robotiq_c_model_control/c_model_ethercat_client.h"
+
+#include "robotiq_ethercat/ethercat_manager.h"
+
+// See Robotiq's documentation for the register mapping
+
+// An effort to keep the lines less than 100 char long
+namespace c_model = robotiq_c_model_control;
+
+c_model::CModelEtherCatClient::CModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, 
+                                                    int slave_no)
+  : manager_(manager)
+  , slave_no_(slave_no)
+{}
+
+/*
+  See support.robotiq.com -> manual for the register output meanings
+*/
+void c_model::CModelEtherCatClient::writeOutputs(const GripperOutput& output)
+{
+  uint8_t map[6] = {0}; // array containing all 6 output registers
+
+  // Pack the Action Request register byte
+  map[0] = (output.rACT & 0x1) | ((output.rGTO << 0x3) & 0x8) | ((output.rATR << 0x4) & 0x10);
+  // registers 1 & 2 reserved by Robotiq
+  map[3] = output.rPR;
+  map[4] = output.rSP;
+  map[5] = output.rFR;
+
+  for (unsigned i = 0; i < 6; ++i)
+  {
+    manager_.write(slave_no_, i, map[i]);
+  }
+}
+
+c_model::CModelEtherCatClient::GripperInput c_model::CModelEtherCatClient::readInputs() const
+{
+  uint8_t map[6];
+
+  for (unsigned i = 0; i < 6; ++i)
+  {
+    map[i] = manager_.readInput(slave_no_, i);
+  }
+
+  // Decode Input Registers
+  GripperInput input;
+  input.gACT = map[0] & 0x1;
+  input.gGTO = (map[0] >> 0x3) & 0x1;
+  input.gSTA = (map[0] >> 0x4) & 0x3;
+  input.gOBJ = (map[0] >> 0x6) & 0x3;
+  // map[1] is reserved by the protocol
+  input.gFLT = map[2] & 0xF;
+  input.gPR = map[3];
+  input.gPO = map[4];
+  input.gCU = map[5];
+
+  return input;
+}
+
+c_model::CModelEtherCatClient::GripperOutput c_model::CModelEtherCatClient::readOutputs() const
+{
+  uint8_t map[6];
+  for (unsigned i = 0; i < 6; ++i)
+  {
+    map[i] = manager_.readOutput(slave_no_, i);
+  }
+
+  GripperOutput output;
+  output.rACT = map[0] & 1;
+  output.rGTO = (map[0] >> 0x3) & 0x1;
+  output.rATR = (map[0] >> 0x4) & 0x1;
+  output.rPR = map[3];
+  output.rSP = map[4];
+  output.rFR = map[5];
+
+  return output;
+}

--- a/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
@@ -38,15 +38,28 @@ int main(int argc, char** argv)
 
   // Parameter names
   std::string ifname;
+  std::string gripper_name;
   int slave_no;
+  bool activate;
+  
 
   nh.param<std::string>("ifname", ifname, "eth0");
   nh.param<int>("slave_number", slave_no, 1);
+  nh.param<bool>("activate", activate, true);
 
   // Start ethercat manager
   EtherCatManager manager(ifname);
   // register client 
   CModelEtherCatClient client(manager, slave_no);
+
+  // conditionally activate the gripper
+  if (activate)
+  {
+    // Check to see if resetting is required? Or always reset?
+    GripperOutput out;
+    out.rACT = 0x1;
+    client.writeOutputs(out);
+  }
 
   // Sorry for the indentation, trying to keep it under 100 chars
   ros::Subscriber sub = 

--- a/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
@@ -14,6 +14,7 @@
   to the same network, you'll need to edit the source file.
 */
 
+// Note that you will likely need to run the following on your binary:
 // sudo setcap cap_net_raw+ep <filename>
 
 
@@ -38,10 +39,8 @@ int main(int argc, char** argv)
 
   // Parameter names
   std::string ifname;
-  std::string gripper_name;
   int slave_no;
-  bool activate;
-  
+  bool activate;  
 
   nh.param<std::string>("ifname", ifname, "eth0");
   nh.param<int>("slave_number", slave_no, 1);

--- a/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
   typedef CModelEtherCatClient::GripperOutput GripperOutput;
   typedef CModelEtherCatClient::GripperInput GripperInput;
 
-  ros::init(argc, argv, "robotiqCModel");
+  ros::init(argc, argv, "robotiq_c_model_gripper_node");
   
   ros::NodeHandle nh ("~");
 
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
   int slave_no;
   bool activate;  
 
-  nh.param<std::string>("ifname", ifname, "eth0");
+  nh.param<std::string>("ifname", ifname, "eth1");
   nh.param<int>("slave_number", slave_no, 1);
   nh.param<bool>("activate", activate, true);
 
@@ -62,10 +62,10 @@ int main(int argc, char** argv)
 
   // Sorry for the indentation, trying to keep it under 100 chars
   ros::Subscriber sub = 
-        nh.subscribe<GripperOutput>("/CModelRobotOutput", 1,
+        nh.subscribe<GripperOutput>("output", 1,
                                     boost::bind(changeCallback, boost::ref(client), _1));
 
-  ros::Publisher pub = nh.advertise<GripperInput>("/CModelRobotInput", 100);
+  ros::Publisher pub = nh.advertise<GripperInput>("input", 100);
 
   ros::Rate rate(10); // 10 Hz
 

--- a/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
+++ b/robotiq_c_model_control/src/robotiq_c_model_control/c_model_ethercat_node.cpp
@@ -1,0 +1,69 @@
+#include "ros/ros.h"
+
+#include <boost/bind.hpp>
+#include <boost/ref.hpp>
+
+#include "robotiq_c_model_control/c_model_ethercat_client.h"
+#include <robotiq_c_model_control/CModel_robot_input.h>
+#include "robotiq_ethercat/ethercat_manager.h"
+
+
+/*
+  Note that this code currently works only to control ONE CModel gripper
+  attached to ONE network interface. If you want to add more grippers
+  to the same network, you'll need to edit the source file.
+*/
+
+// sudo setcap cap_net_raw+ep <filename>
+
+
+void changeCallback(robotiq_c_model_control::CModelEtherCatClient& client,
+                    const robotiq_c_model_control::CModelEtherCatClient::GripperOutput::ConstPtr& msg)
+{
+  client.writeOutputs(*msg);
+}
+
+
+int main(int argc, char** argv)
+{
+  using robotiq_ethercat::EtherCatManager;
+  using robotiq_c_model_control::CModelEtherCatClient;
+
+  typedef CModelEtherCatClient::GripperOutput GripperOutput;
+  typedef CModelEtherCatClient::GripperInput GripperInput;
+
+  ros::init(argc, argv, "robotiqCModel");
+  
+  ros::NodeHandle nh ("~");
+
+  // Parameter names
+  std::string ifname;
+  int slave_no;
+
+  nh.param<std::string>("ifname", ifname, "eth0");
+  nh.param<int>("slave_number", slave_no, 1);
+
+  // Start ethercat manager
+  EtherCatManager manager(ifname);
+  // register client 
+  CModelEtherCatClient client(manager, slave_no);
+
+  // Sorry for the indentation, trying to keep it under 100 chars
+  ros::Subscriber sub = 
+        nh.subscribe<GripperOutput>("/CModelRobotOutput", 1,
+                                    boost::bind(changeCallback, boost::ref(client), _1));
+
+  ros::Publisher pub = nh.advertise<GripperInput>("/CModelRobotInput", 100);
+
+  ros::Rate rate(10); // 10 Hz
+
+  while (ros::ok()) 
+  {
+    CModelEtherCatClient::GripperInput input = client.readInputs();
+    pub.publish(input);
+    ros::spinOnce();
+    rate.sleep();
+  }
+
+  return 0;
+}

--- a/robotiq_ethercat/CMakeLists.txt
+++ b/robotiq_ethercat/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(robotiq_ethercat)
+
+find_package(catkin REQUIRED COMPONENTS
+  ethercat_soem
+  roscpp
+)
+
+catkin_package(
+   INCLUDE_DIRS include
+   LIBRARIES robotiq_ethercat
+   CATKIN_DEPENDS ethercat_soem roscpp
+)
+
+include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(robotiq_ethercat
+ include/robotiq_ethercat/ethercat_manager.h
+ src/ethercat_manager.cpp
+)
+
+install(TARGETS robotiq_ethercat
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)

--- a/robotiq_ethercat/README.md
+++ b/robotiq_ethercat/README.md
@@ -1,0 +1,15 @@
+## Robotiq Ethercat
+This package provides an interface for interfacing with an ethercat network. With the current architecture, a single process is associated with a single network and that process must be aware of all slaves it will communicate with.
+
+### Maintainer
+- Jonathan Meyer (jonathan.meyer@swri.org)
+
+### Dependencies
+
+This package uses a 'catkinized' version of the [OpenEtherCAT Society's Master Library](https://github.com/OpenEtherCATsociety/SOEM).
+
+## Common Issues
+Please note:
+ - VMs probably won't work.
+ - You need a dedicated ethernet card for the EtherCAT network. I haven't had luck using eth0.
+ - If you're running Ubuntu, you'll probably need to run ```sudo setcap cap_net_raw+ep``` on the ```c_model_ethercat_node``` executable before it will work. Otherwise you'll get a "Could not initialize SOEM" error. This executable can be found under the same package name in your <workspace_home>/devel/ directory.

--- a/robotiq_ethercat/include/robotiq_ethercat/ethercat_manager.h
+++ b/robotiq_ethercat/include/robotiq_ethercat/ethercat_manager.h
@@ -1,0 +1,93 @@
+#ifndef ETHERCAT_MANAGER_H
+#define ETHERCAT_MANAGER_H
+
+#include <stdexcept>
+#include <string>
+
+#include <stdint.h>
+
+#include <boost/scoped_array.hpp>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+
+namespace robotiq_ethercat
+{
+
+/**
+ * \brief EtherCAT exception. Currently this is only thrown in the event
+ *        of a failure to construct an EtherCat manager.
+ */
+class EtherCatError : public std::runtime_error
+{
+public:
+  explicit EtherCatError(const std::string& what)
+    : std::runtime_error(what)
+  {}
+};
+
+/**
+ * \brief This class provides a CPP interface to the SimpleOpenEthercatMaster library
+ * Given the name of an ethernet device, such as "eth0", it will connect,
+ * start a thread that cycles data around the network, and provide read/write
+ * access to the underlying io map.
+ *
+ * Please note that as used in these docs, 'Input' and 'Output' are relative to
+ * your program. So the 'Output' registers are the ones you write to, for example.
+ */
+class EtherCatManager
+{
+public:
+  /**
+   * \brief Constructs and initializes the ethercat slaves on a given network interface.
+   *
+   * @param[in] ifname the name of the network interface that the ethercat chain 
+   *                   is connected to (i.e. "eth0")
+   *
+   * Constructor can throw EtherCatError exception if SOEM could not be 
+   * initialized.
+   */
+  EtherCatManager(const std::string& ifname);
+  
+  ~EtherCatManager();
+
+  /**
+  * \brief writes 'value' to the 'channel-th' output-register of the given 'slave'
+  *  
+  * @param[in] slave_no The slave number of the device to write to (>= 1)
+  * @param[in] channel The byte offset into the output IOMap to write value to
+  * @param[in] value The byte value to write
+  *
+  * This method currently makes no attempt to catch out of bounds errors. Make
+  * sure you know your IOMap bounds.
+  */
+  void write(int slave_no, uint8_t channel, uint8_t value);
+
+  /**
+  * \brief Reads the "channel-th" input-register of the given slave no
+  *  
+  * @param[in] slave_no The slave number of the device to read from (>= 1)
+  * @param[in] channel The byte offset into the input IOMap to read from
+  */
+  uint8_t readInput(int slave_no, uint8_t channel) const;
+
+  /**
+  * \brief Reads the "channel-th" output-register of the given slave no
+  *  
+  * @param[in] slave_no The slave number of the device to read from (>= 1)
+  * @param[in] channel The byte offset into the output IOMap to read from
+  */
+  uint8_t readOutput(int slave_no, uint8_t channel) const;
+
+private:
+  bool initSoem(const std::string& ifname);
+
+  const std::string ifname_;
+  boost::scoped_array<uint8_t> iomap_;
+  boost::thread cycle_thread_;
+  mutable boost::mutex iomap_mutex_;
+  bool stop_flag_;
+};
+
+}
+
+#endif

--- a/robotiq_ethercat/package.xml
+++ b/robotiq_ethercat/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package>
+  <name>robotiq_ethercat</name>
+  <version>0.1.0</version>
+  <description>
+    <p>
+      ROS-Industrial support stack for facilitating communication with EtherCAT networks.
+    </p>
+  </description>
+
+  <author>Jonathan Meyer</author>
+  <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>ethercat_soem</build_depend>
+  <build_depend>roscpp</build_depend>
+  <run_depend>ethercat_soem</run_depend>
+  <run_depend>roscpp</run_depend>
+
+</package>

--- a/robotiq_ethercat/src/ethercat_manager.cpp
+++ b/robotiq_ethercat/src/ethercat_manager.cpp
@@ -1,0 +1,226 @@
+#include "robotiq_ethercat/ethercat_manager.h"
+
+#include <string.h>
+
+#include <unistd.h>
+
+#include <boost/ref.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+#include <ethercat_soem/ethercattype.h>
+#include <ethercat_soem/nicdrv.h>
+#include <ethercat_soem/ethercatbase.h>
+#include <ethercat_soem/ethercatmain.h>
+#include <ethercat_soem/ethercatdc.h>
+#include <ethercat_soem/ethercatcoe.h>
+#include <ethercat_soem/ethercatfoe.h>
+#include <ethercat_soem/ethercatconfig.h>
+#include <ethercat_soem/ethercatprint.h>
+
+#include <ros/ros.h>
+
+namespace 
+{
+  static const unsigned THREAD_SLEEP_TIME = 10000; // 10 ms
+  static const unsigned EC_TIMEOUTMON = 500;
+
+  void handleErrors()
+  {
+    /* one ore more slaves are not responding */
+    ec_group[0].docheckstate = FALSE;
+    ec_readstate();
+    for (int slave = 1; slave <= ec_slavecount; slave++)
+    {
+      if ((ec_slave[slave].group == 0) && (ec_slave[slave].state != EC_STATE_OPERATIONAL))
+      {
+        ec_group[0].docheckstate = TRUE;
+        if (ec_slave[slave].state == (EC_STATE_SAFE_OP + EC_STATE_ERROR))
+        {
+          ROS_ERROR("ERROR : slave %d is in SAFE_OP + ERROR, attempting ack.\n", slave);
+          ec_slave[slave].state = (EC_STATE_SAFE_OP + EC_STATE_ACK);
+          ec_writestate(slave);
+        }
+        else if(ec_slave[slave].state == EC_STATE_SAFE_OP)
+        {
+          ROS_WARN("WARNING : slave %d is in SAFE_OP, change to OPERATIONAL.\n", slave);
+          ec_slave[slave].state = EC_STATE_OPERATIONAL;
+          ec_writestate(slave);
+        }
+        else if(ec_slave[slave].state > 0)
+        {
+          if (ec_reconfig_slave(slave, EC_TIMEOUTMON))
+          {
+            ec_slave[slave].islost = FALSE;
+            ROS_INFO("MESSAGE : slave %d reconfigured\n",slave);
+          }
+        }
+        else if(!ec_slave[slave].islost)
+        {
+          /* re-check state */
+          ec_statecheck(slave, EC_STATE_OPERATIONAL, EC_TIMEOUTRET);
+          if (!ec_slave[slave].state)
+          {
+            ec_slave[slave].islost = TRUE;
+            ROS_ERROR("ERROR : slave %d lost\n",slave);
+          }
+        }
+      }
+      if (ec_slave[slave].islost)
+      {
+        if(!ec_slave[slave].state)
+        {
+          if (ec_recover_slave(slave, EC_TIMEOUTMON))
+          {
+            ec_slave[slave].islost = FALSE;
+            ROS_INFO("MESSAGE : slave %d recovered\n",slave);
+          }
+        }
+        else
+        {
+          ec_slave[slave].islost = FALSE;
+          ROS_INFO("MESSAGE : slave %d found\n",slave);
+        }
+      }
+    }
+  }
+
+  void cycleWorker(boost::mutex& mutex, bool& stop_flag)
+  {
+    while (!stop_flag) 
+    {
+      int expected_wkc = (ec_group[0].outputsWKC * 2) + ec_group[0].inputsWKC;
+      int sent, wkc;
+      {
+        boost::mutex::scoped_lock lock(mutex);
+        sent = ec_send_processdata();
+        wkc = ec_receive_processdata(EC_TIMEOUTRET);
+      }
+
+      if (wkc < expected_wkc)
+      {
+        handleErrors();
+      }
+
+      usleep(THREAD_SLEEP_TIME);
+    }
+  }
+
+} // end of anonymous namespace
+
+
+robotiq_ethercat::EtherCatManager::EtherCatManager(const std::string& ifname)
+  : ifname_(ifname)
+  , stop_flag_(false)
+{
+  if (initSoem(ifname)) 
+  {
+    cycle_thread_ = boost::thread(cycleWorker, 
+                                  boost::ref(iomap_mutex_),
+                                  boost::ref(stop_flag_));
+  } 
+  else 
+  {
+    // construction failed
+    throw EtherCatError("Could not initialize SOEM");
+  }
+}
+
+robotiq_ethercat::EtherCatManager::~EtherCatManager()
+{
+  stop_flag_ = true;
+  ec_close();
+  cycle_thread_.join();
+}
+
+void robotiq_ethercat::EtherCatManager::write(int slave_no, uint8_t channel, uint8_t value)
+{
+  boost::mutex::scoped_lock lock(iomap_mutex_);
+  ec_slave[slave_no].outputs[channel] = value;
+}
+
+uint8_t robotiq_ethercat::EtherCatManager::readInput(int slave_no, uint8_t channel) const
+{
+  boost::mutex::scoped_lock lock(iomap_mutex_);
+  return ec_slave[slave_no].inputs[channel];
+}
+
+uint8_t robotiq_ethercat::EtherCatManager::readOutput(int slave_no, uint8_t channel) const
+{
+  boost::mutex::scoped_lock lock(iomap_mutex_);
+  return ec_slave[slave_no].outputs[channel];
+}
+
+bool robotiq_ethercat::EtherCatManager::initSoem(const std::string& ifname)
+{
+  // Copy string contents because SOEM library doesn't 
+    // practice const correctness
+    const static unsigned MAX_BUFF_SIZE = 1024;
+    char buffer[MAX_BUFF_SIZE];
+    size_t name_size = ifname_.size();
+    if (name_size > sizeof(buffer) - 1) 
+    {
+      ROS_ERROR("Ifname %s exceeds maximum size of %u bytes", ifname.c_str(), MAX_BUFF_SIZE);
+      return false;
+    }
+    std::strncpy(buffer, ifname_.c_str(), MAX_BUFF_SIZE);
+
+    ROS_INFO("Initializing etherCAT master");
+
+    if (!ec_init(buffer))
+    {
+      ROS_ERROR("Could not initialize ethercat driver");
+      return false;
+    }
+
+    /* find and auto-config slaves */
+    if (ec_config_init(FALSE) <= 0)
+    {
+      ROS_WARN("No slaves found on %s", ifname_.c_str());
+      return false;
+    }
+
+    ROS_INFO("SOEM found and configured %d slaves", ec_slavecount);
+
+    unsigned map_size = ec_slave[0].Obytes + ec_slave[0].Ibytes;
+    iomap_.reset(new uint8_t[map_size]);
+
+    int iomap_size = ec_config_map(iomap_.get());
+    ROS_INFO("SOEM IOMap size: %d", iomap_size);
+
+    // locates dc slaves - ???
+    ec_configdc();
+
+    // '0' here addresses all slaves
+    if (ec_statecheck(0, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE*4) != EC_STATE_SAFE_OP)
+    {
+      ROS_ERROR("Could not set EC_STATE_SAFE_OP");
+      return false;
+    }
+
+    /* 
+      This section attempts to bring all slaves to operational status. It does so
+      by attempting to set the status of all slaves (ec_slave[0]) to operational,
+      then proceeding through 40 send/recieve cycles each waiting up to 50 ms for a
+      response about the status. 
+    */
+    ec_slave[0].state = EC_STATE_OPERATIONAL;
+    ec_send_processdata();
+    ec_receive_processdata(EC_TIMEOUTRET);
+
+    ec_writestate(0);
+    int chk = 40;
+    do {
+      ec_send_processdata();
+      ec_receive_processdata(EC_TIMEOUTRET);
+      ec_statecheck(0, EC_STATE_OPERATIONAL, 50000); // 50 ms wait for state check
+    } while (chk-- && (ec_slave[0].state != EC_STATE_OPERATIONAL));
+
+    if(ec_statecheck(0,EC_STATE_OPERATIONAL, EC_TIMEOUTSTATE) != EC_STATE_OPERATIONAL)
+    {
+      ROS_ERROR_STREAM("OPERATIONAL state not set, exiting");
+      return false;
+    }
+
+    ROS_INFO("Finished configuration successfully");
+    return true;
+}

--- a/robotiq_s_model_control/CMakeLists.txt
+++ b/robotiq_s_model_control/CMakeLists.txt
@@ -1,7 +1,7 @@
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_s_model_control)
-find_package(catkin REQUIRED rospy message_generation)
+find_package(catkin REQUIRED rospy message_generation roscpp robotiq_ethercat)
 
 #set the default path for built executables to the "bin" directory
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
@@ -30,9 +30,26 @@ generate_messages()
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    CATKIN_DEPENDS rospy message_runtime
+    CATKIN_DEPENDS rospy message_runtime roscpp robotiq_ethercat
 )
 
+include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${robotiq_ethercat_INCLUDE_DIRS}
+)
+
+add_executable(s_model_ethercat_node
+  src/robotiq_s_model_control/s_model_ethercat_node.cpp
+  src/robotiq_s_model_control/s_model_ethercat_client.cpp
+)
+
+target_link_libraries(s_model_ethercat_node
+   ${robotiq_ethercat_LIBRARIES}
+   ${catkin_LIBRARIES}
+)
+
+add_dependencies(c_model_ethercat_node robotiq_c_model_control_generate_messages_cpp)
 #############
 ## Install ##
 #############

--- a/robotiq_s_model_control/CMakeLists.txt
+++ b/robotiq_s_model_control/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(s_model_ethercat_node
    ${catkin_LIBRARIES}
 )
 
-add_dependencies(c_model_ethercat_node robotiq_c_model_control_generate_messages_cpp)
+add_dependencies(s_model_ethercat_node robotiq_s_model_control_generate_messages_cpp)
 #############
 ## Install ##
 #############

--- a/robotiq_s_model_control/include/robotiq_s_model_control/s_model_ethercat_client.h
+++ b/robotiq_s_model_control/include/robotiq_s_model_control/s_model_ethercat_client.h
@@ -1,0 +1,66 @@
+#ifndef S_MODEL_ETHERCAT_CLIENT_H
+#define S_MODEL_ETHERCAT_CLIENT_H
+
+#include <robotiq_s_model_control/SModel_robot_output.h>
+#include <robotiq_s_model_control/SModel_robot_input.h>
+
+// Forward declaration of EtherCatManager
+namespace robotiq_ethercat
+{
+  class EtherCatManager;
+}
+
+namespace robotiq_s_model_control
+{
+
+/**
+ * \brief This class provides a client for the EtherCAT manager object that
+ *        can translate robot input/output messages and translate them to
+ *        the underlying IO Map.
+ */
+
+class SModelEtherCatClient
+{
+public:
+  typedef robotiq_s_model_control::SModel_robot_output GripperOutput;
+  typedef robotiq_s_model_control::SModel_robot_input GripperInput;
+
+  /**
+   * \brief Constructs a control interface to a S Model Robotiq gripper on
+   *        the given ethercat network and the given slave_no.
+   *
+   * @param[in] manager The interface to an EtherCAT network that the gripper
+   *                    is connected to.
+   *
+   * @param[in] slave_no The slave number of the gripper on the EtherCAT network
+   *                     (>= 1)
+   */
+  SModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, int slave_no);
+
+  /**
+   * \brief Write the given set of control flags to the memory of the gripper
+   *
+   * @param[in] output The set of output-register values to write to the gripper
+   */
+  void writeOutputs(const GripperOutput& output);
+
+  /**
+   * \brief Reads set of input-register values from the gripper.
+   * \return The gripper input registers as read from the controller IOMap
+   */
+  GripperInput readInputs() const;
+
+  /**
+   * \brief Reads set of output-register values from the gripper.
+   * \return The gripper output registers as read from the controller IOMap
+   */
+  GripperOutput readOutputs() const;
+
+private:
+  robotiq_ethercat::EtherCatManager& manager_;
+  const int slave_no_;
+};
+
+}
+
+#endif

--- a/robotiq_s_model_control/launch/s_model_ethercat.launch
+++ b/robotiq_s_model_control/launch/s_model_ethercat.launch
@@ -1,0 +1,15 @@
+<launch>
+  <arg name="gripper_name" default="gripper" />
+  <arg name="slave_number" default="1" />
+  <arg name="activate" default="True" />
+  <arg name="ifname" default="enp0s20u1" />
+
+  <node pkg="robotiq_s_model_control" type="s_model_ethercat_node" name="gripper_server" output="screen">
+      <param name="ifname" type="str" value="$(arg ifname)" />
+      <param name="activate" type="bool" value="$(arg activate)" />
+      <param name="slave_number" type="int" value="$(arg slave_number)"/>
+
+      <remap from="output" to="/$(arg gripper_name)/output" />
+      <remap from="input" to="/$(arg gripper_name)/input" />
+    </node>
+</launch>

--- a/robotiq_s_model_control/package.xml
+++ b/robotiq_s_model_control/package.xml
@@ -10,8 +10,12 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>robotiq_ethercat</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>robotiq_ethercat</run_depend>
 
   <export>
 

--- a/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
+++ b/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
@@ -76,8 +76,8 @@ SModelEtherCatClient::GripperInput SModelEtherCatClient::readInputs() const
   // Object Status
   input.gDTA = map[1] & 0x3;
   input.gDTB = (map[1] >> 0x2) & 0x3;
-  input.gDTB = (map[1] >> 0x4) & 0x3;
-  input.gDTB = (map[1] >> 0x6) & 0x3;
+  input.gDTC = (map[1] >> 0x4) & 0x3;
+  input.gDTS = (map[1] >> 0x6) & 0x3;
 
   // Fault Status
   input.gFLT = map[2] & 0xF;

--- a/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
+++ b/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_client.cpp
@@ -1,0 +1,147 @@
+#include "robotiq_s_model_control/s_model_ethercat_client.h"
+
+#include "robotiq_ethercat/ethercat_manager.h"
+
+// See Robotiq's documentation for the register mapping
+
+// An effort to keep the lines less than 100 char long
+namespace robotiq_s_model_control
+{
+SModelEtherCatClient::SModelEtherCatClient(robotiq_ethercat::EtherCatManager& manager, 
+                                                    int slave_no)
+  : manager_(manager)
+  , slave_no_(slave_no)
+{}
+
+/*
+  See support.robotiq.com -> manual for the register output meanings
+*/
+void SModelEtherCatClient::writeOutputs(const GripperOutput& output)
+{
+  uint8_t map[15] = {0}; // array containing all 15 output registers
+
+  // Pack the Action Request register byte
+  map[0] = (output.rACT & 0x1) | (output.rMOD << 0x1) & 0x6 | ((output.rGTO << 0x3) & 0x8) | ((output.rATR << 0x4) & 0x10);
+
+  // Pack the Gripper Options register byte
+  map[1] =  ((output.rICF << 0x2) & 0x4) | ((output.rICS << 0x3) & 0x8);
+
+  // map[2] is empty
+
+  // Requested Position, Speed and Force (Finger A).
+  map[3]  = output.rPRA;
+  map[4]  = output.rSPA;
+  map[5]  = output.rFRA;
+
+  // Finger B
+  map[6]  = output.rPRB;
+  map[7]  = output.rSPB;
+  map[8]  = output.rFRB;
+
+  // Finger C
+  map[9]  = output.rPRC;
+  map[10] = output.rSPC;
+  map[11] = output.rFRC;
+
+  // Scissor Mode
+  map[12] = output.rPRS;
+  map[13] = output.rSPS;
+  map[14] = output.rFRS;
+
+  for (unsigned i = 0; i < 15; ++i)
+  {
+    manager_.write(slave_no_, i, map[i]);
+  }
+}
+
+SModelEtherCatClient::GripperInput SModelEtherCatClient::readInputs() const
+{
+  uint8_t map[15];
+
+  for (unsigned i = 0; i < 15; ++i)
+  {
+    map[i] = manager_.readInput(slave_no_, i);
+  }
+
+  // Decode Input Registers
+  GripperInput input;
+
+  // Gripper Status
+  input.gACT = map[0] & 0x1;
+  input.gMOD = (map[0] >> 0x1) & 0x3;
+  input.gGTO = (map[0] >> 0x3) & 0x1;
+  input.gIMC = (map[0] >> 0x4) & 0x3;
+  input.gSTA = (map[0] >> 0x6) & 0x3;
+
+  // Object Status
+  input.gDTA = map[1] & 0x3;
+  input.gDTB = (map[1] >> 0x2) & 0x3;
+  input.gDTB = (map[1] >> 0x4) & 0x3;
+  input.gDTB = (map[1] >> 0x6) & 0x3;
+
+  // Fault Status
+  input.gFLT = map[2] & 0xF;
+
+  // Requested Position, Speed and Force (Finger A).
+  input.gPRA = map[3];
+  input.gPOA = map[4];
+  input.gCUA = map[5];
+
+  // Finger B
+  input.gPRB = map[6];
+  input.gPOB = map[7];
+  input.gCUB = map[8];
+
+  // Finger C
+  input.gPRC = map[9];
+  input.gPOC = map[10];
+  input.gCUC = map[11];
+
+  // Scissor Mode
+  input.gPRS = map[12];
+  input.gPOS = map[13];
+  input.gCUS = map[14];
+
+  return input;
+}
+
+SModelEtherCatClient::GripperOutput SModelEtherCatClient::readOutputs() const
+{
+  uint8_t map[15];
+  for (unsigned i = 0; i < 15; ++i)
+  {
+    map[i] = manager_.readOutput(slave_no_, i);
+  }
+
+  GripperOutput output;
+  output.rACT = map[0] & 1;
+  output.rMOD = (map[0] >> 0x1) & 0x6;
+  output.rGTO = (map[0] >> 0x3) & 0x1;
+  output.rATR = (map[0] >> 0x4) & 0x1;
+
+  output.rICF = (map[1] >> 0x2) & 0x4;
+  output.rICS = (map[1] >> 0x3) & 0x8;
+
+  // Finger A
+  output.rPRA = map[3];
+  output.rSPA = map[4];
+  output.rFRA = map[5];
+
+  // Finger B
+  output.rPRB = map[6];
+  output.rSPB = map[7];
+  output.rFRB = map[8];
+
+  // Finger C
+  output.rPRC = map[9];
+  output.rSPC = map[10];
+  output.rFRC = map[11];
+
+  // Scissor Mode
+  output.rPRS = map[12];
+  output.rSPS = map[13];
+  output.rFRS = map[14];
+
+  return output;
+}
+} // end of robotiq_s_model_control namespace

--- a/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_node.cpp
+++ b/robotiq_s_model_control/src/robotiq_s_model_control/s_model_ethercat_node.cpp
@@ -1,0 +1,81 @@
+#include "ros/ros.h"
+
+#include <boost/bind.hpp>
+#include <boost/ref.hpp>
+
+#include "robotiq_s_model_control/s_model_ethercat_client.h"
+#include <robotiq_s_model_control/SModel_robot_input.h>
+#include "robotiq_ethercat/ethercat_manager.h"
+
+
+/*
+  Note that this code currently works only to control ONE SModel gripper
+  attached to ONE network interface. If you want to add more grippers
+  to the same network, you'll need to edit the source file.
+*/
+
+// Note that you will likely need to run the following on your binary:
+// sudo setcap cap_net_raw+ep <filename>
+
+
+void changeCallback(robotiq_s_model_control::SModelEtherCatClient& client,
+                    const robotiq_s_model_control::SModelEtherCatClient::GripperOutput::ConstPtr& msg)
+{
+  client.writeOutputs(*msg);
+}
+
+
+int main(int argc, char** argv)
+{
+  using robotiq_ethercat::EtherCatManager;
+  using robotiq_s_model_control::SModelEtherCatClient;
+
+  typedef SModelEtherCatClient::GripperOutput GripperOutput;
+  typedef SModelEtherCatClient::GripperInput GripperInput;
+
+  ros::init(argc, argv, "robotiq_s_model_gripper_node");
+  
+  ros::NodeHandle nh ("~");
+
+  // Parameter names
+  std::string ifname;
+  int slave_no;
+  bool activate;  
+
+  nh.param<std::string>("ifname", ifname, "enp9s0");
+  nh.param<int>("slave_number", slave_no, 1);
+  nh.param<bool>("activate", activate, true);
+
+  // Start ethercat manager
+  EtherCatManager manager(ifname);
+  // register client 
+  SModelEtherCatClient client(manager, slave_no);
+
+  // conditionally activate the gripper
+  if (activate)
+  {
+    // Check to see if resetting is required? Or always reset?
+    GripperOutput out;
+    out.rACT = 0x1;
+    client.writeOutputs(out);
+  }
+
+  // Sorry for the indentation, trying to keep it under 100 chars
+  ros::Subscriber sub = 
+        nh.subscribe<GripperOutput>("output", 1,
+                                    boost::bind(changeCallback, boost::ref(client), _1));
+
+  ros::Publisher pub = nh.advertise<GripperInput>("input", 100);
+
+  ros::Rate rate(10); // 10 Hz
+
+  while (ros::ok()) 
+  {
+    SModelEtherCatClient::GripperInput input = client.readInputs();
+    pub.publish(input);
+    ros::spinOnce();
+    rate.sleep();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This pull request adds EtherCAT protocol support for the Robotiq gripper. It defines an EtherCatManager class which handles communication with the ethercat network via the SOEM library which this depends on. Adding this library will be handled soon, but can currently be found in my fork https://github.com/Jmeyer1292/ethercat-soem. 

Each device defines an ethercat client that communicates directly with the manager, the latter of which only deals in bytes. 

**\* The main limitation of this implementation is that all devices on a given ethercat network need to be handled in a single process. ***

On top of this system is a c model gripper control node made in the style of the existing python nodes. See the launch file added to robotiq_c_model_control for more details.

Despite its limitations, I think this will be effective for many users. My Robotiq EtherCAT control box only has a single ethernet connection so it will only work by itself anyway. If additional capability is required, I have ideas for expanding capabilities but I wanted to get this out to folks.

Please note that:
1. VMs probably won't work
2. You need a dedicated ethernet card for the EtherCAT network. Don't use eth0.
3. You'll probably need to run "sudo setcap cap_net_raw+ep <filename>" on the c_model_ethercat_node before it will work. Otherwise you'll get a "Could not initialize SOEM" error. 
