### PR TITLE
Fix for issues 10 & 22: remove wrong and unneeded 'requires' entry from setup args

### DIFF
--- a/robotiq_modbus_rtu/package.xml
+++ b/robotiq_modbus_rtu/package.xml
@@ -5,20 +5,15 @@
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
   <maintainer email="kphawkins@gatech.edu">Kelsey Hawkins</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/robotiq</url>
+  <url type="website">http://wiki.ros.org/robotiq</url>
   <author>Nicolas Lauzier (Robotiq inc.)</author>
   <author email="kphawkins@gatech.edu">Kelsey Hawkins</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>python-pymodbus</build_depend>
   <build_depend>rospy</build_depend>
 
   <run_depend>python-pymodbus</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>python-pymodbus</run_depend>
-
-  <export>
-
-  </export>
 </package>

--- a/robotiq_modbus_rtu/setup.py
+++ b/robotiq_modbus_rtu/setup.py
@@ -7,7 +7,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 setup_args = generate_distutils_setup(
     packages=['robotiq_modbus_rtu'],
     package_dir={'': 'src'},
-    requires=['rospy', 'python-pymodbus']
 )
 
 setup(**setup_args)

--- a/robotiq_modbus_tcp/package.xml
+++ b/robotiq_modbus_tcp/package.xml
@@ -4,19 +4,14 @@
   <description>A stack to communicate with Robotiq grippers using the Modbus TCP protocol</description>
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/robotiq</url>
+  <url type="website">http://wiki.ros.org/robotiq</url>
   <author>Nicolas Lauzier (Robotiq inc.)</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>python-pymodbus</build_depend>
   <build_depend>rospy</build_depend>
 
   <run_depend>python-pymodbus</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>python-pymodbus</run_depend>  
-
-  <export>
-
-  </export>
 </package>

--- a/robotiq_modbus_tcp/setup.py
+++ b/robotiq_modbus_tcp/setup.py
@@ -7,7 +7,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 setup_args = generate_distutils_setup(
     packages=['robotiq_modbus_tcp'],
     package_dir={'': 'src'},
-    requires=['rospy', 'python-pymodbus']
 )
 
 setup(**setup_args)


### PR DESCRIPTION
This should make the docjob(s) run to completion again and make `catkin_make install` work again.

I opted to remove the entire `requires` entry as it is unneeded:
- catkin pkgs should be installed using catkin, not `setup.py`
- dependency is already expressed in the pkg manifest

Upon acceptance this should probably be cherry-picked into `groovy-devel` and `hydro-devel`.

Perhaps a quick re-release of `hydro-devel` is then in order, as the buildfarm will be disabled soon.
