### PR TITLE
Issue #39 soem lib

### DIFF
--- a/robotiq_ethercat/CMakeLists.txt
+++ b/robotiq_ethercat/CMakeLists.txt
@@ -2,20 +2,23 @@ cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_ethercat)
 
 find_package(catkin REQUIRED COMPONENTS
-  ethercat_soem
+  soem
   roscpp
 )
 
 catkin_package(
    INCLUDE_DIRS include
    LIBRARIES robotiq_ethercat
-   CATKIN_DEPENDS ethercat_soem roscpp
+   CATKIN_DEPENDS soem roscpp
 )
 
 include_directories(include)
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ##/opt/ros/indigo/include/soem
 )
+
+Message("Include directories: " ${robotiq_ethercat_INCLUDE_DIRS})
 
 add_library(robotiq_ethercat
  include/robotiq_ethercat/ethercat_manager.h

--- a/robotiq_ethercat/CMakeLists.txt
+++ b/robotiq_ethercat/CMakeLists.txt
@@ -12,13 +12,13 @@ catkin_package(
    CATKIN_DEPENDS soem roscpp
 )
 
-include_directories(include)
-include_directories(
+include_directories(include
   ${catkin_INCLUDE_DIRS}
-  ##/opt/ros/indigo/include/soem
+  ## The following work around allows SOEM headers to include other SOEM headers.
+  ## SOEM headers assume all headers are installed in a flat directory structure
+  ## See https://github.com/smits/soem/issues/4 for more information.
+  ${soem_INCLUDE_DIRS}/soem
 )
-
-Message("Include directories: " ${robotiq_ethercat_INCLUDE_DIRS})
 
 add_library(robotiq_ethercat
  include/robotiq_ethercat/ethercat_manager.h

--- a/robotiq_ethercat/README.md
+++ b/robotiq_ethercat/README.md
@@ -4,10 +4,6 @@ This package provides an interface for interfacing with an ethercat network. Wit
 ### Maintainer
 - Jonathan Meyer (jonathan.meyer@swri.org)
 
-### Dependencies
-
-This package uses a 'catkinized' version of the [OpenEtherCAT Society's Master Library](https://github.com/OpenEtherCATsociety/SOEM).
-
 ## Common Issues
 Please note:
  - VMs probably won't work.

--- a/robotiq_ethercat/package.xml
+++ b/robotiq_ethercat/package.xml
@@ -14,9 +14,9 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>ethercat_soem</build_depend>
+  <build_depend>soem</build_depend>
   <build_depend>roscpp</build_depend>
-  <run_depend>ethercat_soem</run_depend>
+  <run_depend>soem</run_depend>
   <run_depend>roscpp</run_depend>
 
 </package>

--- a/robotiq_ethercat/src/ethercat_manager.cpp
+++ b/robotiq_ethercat/src/ethercat_manager.cpp
@@ -7,15 +7,15 @@
 #include <boost/ref.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 
-#include <ethercat_soem/ethercattype.h>
-#include <ethercat_soem/nicdrv.h>
-#include <ethercat_soem/ethercatbase.h>
-#include <ethercat_soem/ethercatmain.h>
-#include <ethercat_soem/ethercatdc.h>
-#include <ethercat_soem/ethercatcoe.h>
-#include <ethercat_soem/ethercatfoe.h>
-#include <ethercat_soem/ethercatconfig.h>
-#include <ethercat_soem/ethercatprint.h>
+#include <soem/ethercattype.h>
+#include <soem/nicdrv.h>
+#include <soem/ethercatbase.h>
+#include <soem/ethercatmain.h>
+#include <soem/ethercatdc.h>
+#include <soem/ethercatcoe.h>
+#include <soem/ethercatfoe.h>
+#include <soem/ethercatconfig.h>
+#include <soem/ethercatprint.h>
 
 #include <ros/ros.h>
 


### PR DESCRIPTION
Removes dependency on custom SOEM library and instead uses [standard SOEM](http://wiki.ros.org/soem).

Tested change on Ethercat hardware.
