### PR TITLE
Fixed the discrepancy between the visual and collision origins of link_0

### DIFF
--- a/robotiq_s_model_visualization/cfg/s-model_finger_articulated_macro.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_finger_articulated_macro.xacro
@@ -20,7 +20,7 @@ finger(i.e. finger_1, etc...).
 				</material>
 			</visual>
 			<collision>	
-				<origin xyz="-0.0455 0.0414 0.036" rpy="0 3.1416 -1.57"/>
+				<origin xyz="0.020 0 0" rpy="0 0 0"/>
 				<geometry>
 					<mesh filename="package://robotiq_s_model_visualization/meshes/s-model_articulated/collision/link_0.STL" />
 				</geometry>


### PR DESCRIPTION
For some reason, the origin tags for link_0 visual and collision were different. This resulted in motion planner thinking there was a collision even when visually there was no collision.
