### PR TITLE
change prefix to optional rosparameter

### DIFF
--- a/robotiq_joint_state_publisher/README.md
+++ b/robotiq_joint_state_publisher/README.md
@@ -11,5 +11,5 @@ Run:
 
 or
 
-`rosrun robotiq_joint_state_publisher s_model_joint_states <gripper_prefix>`
+`rosrun robotiq_joint_state_publisher s_model_joint_states _prefix:=<gripper_prefix>`
 

--- a/robotiq_joint_state_publisher/src/s_model_joint_states.cpp
+++ b/robotiq_joint_state_publisher/src/s_model_joint_states.cpp
@@ -177,19 +177,19 @@ inline std::vector<std::string>  Robotiq3::jointNames() {
  * Main method.
  */
 int main(int argc, char *argv[]) {
-
-  // set user-specified prefix
-  std::string gripper_prefix;
-  if (argc > 1) gripper_prefix = argv[1];
-  else gripper_prefix = "";
-
-  // Create Robotiq3
-  Robotiq3 robotiq(gripper_prefix);
   
   // ROS init, nodehandle, and rate
   ros::init(argc, argv, "s_model_joint_states");
   ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
   ros::Rate loop_rate(20);  // Hz
+
+  // set user-specified prefix
+  std::string gripper_prefix;
+  pnh.param<std::string>("prefix", gripper_prefix, "");
+
+  // Create Robotiq3
+  Robotiq3 robotiq(gripper_prefix);
 
   // joint state publisher
   ros::Publisher joint_pub;


### PR DESCRIPTION
Starting the node via a launch file produced an error:
The joint names were changed to e.g. "__name:=nodenamepalm_finger_joint_1".
To fix this, the commandline argument was changed into an rosparameter.
If you started the node via rosrun:
rosrun robotiq_joint_state_publisher s_model_joint_states "gripper_prefix"
Now you start it with:
rosrun robotiq_joint_state_publisher s_model_joint_states _prefix:="gripper_prefix"
