### PR TITLE
Correct joint limits for s Model

### DIFF
--- a/robotiq_s_model_visualization/cfg/s-model_articulated_macro.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_articulated_macro.xacro
@@ -40,21 +40,19 @@ there are multiple hands then a prefix followed by an "_" is needed.
 		<!-- end of link list -->
 		<!-- joint list -->
 
-		<!-- WARNING: LIMITS NOT CORRECT -->
 		<joint name="${prefix}palm_finger_1_joint" type="revolute">
 			<parent link="${prefix}palm"/>
 			<child link="${prefix}finger_1_link_0"/>
 			<axis xyz="0 1 0"/>
 			<origin xyz="-0.0455 0.0214 0.036" rpy="0 3.1416 -1.57"/>
-			<limit lower="-0.16" upper="0.25" effort="100" velocity="100"/>
+			<limit lower="-0.1784" upper="0.192" effort="100" velocity="100"/>
 		</joint>
-		<!-- WARNING: LIMITS NOT CORRECT -->
 		<joint name="${prefix}palm_finger_2_joint" type="revolute">
 			<parent link="${prefix}palm"/>
 			<child link="${prefix}finger_2_link_0"/>
 			<axis xyz="0 1 0"/>
 			<origin xyz="-0.0455 0.0214 -0.036" rpy="0 3.1416 -1.57"/>
-			<limit lower="-0.25" upper="0.16" effort="100" velocity="100"/>
+			<limit lower="-0.192" upper="0.1784" effort="100" velocity="100"/>
 		</joint>
 		<joint name="${prefix}palm_finger_middle_joint" type="fixed">
 			<parent link="${prefix}palm"/>

--- a/robotiq_s_model_visualization/cfg/s-model_finger_articulated_macro.xacro
+++ b/robotiq_s_model_visualization/cfg/s-model_finger_articulated_macro.xacro
@@ -105,30 +105,26 @@ finger(i.e. finger_1, etc...).
 
 		<!-- end of link list -->
 		<!-- joint list -->
-		
-		<!-- WARNING: LIMITS NOT CORRECT -->
 		<joint name="${prefix}joint_1" type="revolute">
 			<parent link="${prefix}link_0"/>
 			<child link="${prefix}link_1"/>
 			<axis xyz="0 0 1"/>
 			<origin xyz="0.020 0 0" rpy="0 0 0"/>
-			<limit lower="0" upper="3.1416" effort="100" velocity="100"/>
+			<limit lower="0.0495" upper="1.2218" effort="100" velocity="100"/>
 		</joint>
-		<!-- WARNING: LIMITS NOT CORRECT -->
 		<joint name="${prefix}joint_2" type="revolute">
 			<parent link="${prefix}link_1"/>
 			<child link="${prefix}link_2"/>
 			<axis xyz="0 0 1"/>
 			<origin xyz="0.050 -.028 0" rpy="0 0 -0.52"/>
-			<limit lower="0" upper="3.1416" effort="100" velocity="100"/>
+			<limit lower="0.0" upper="1.5708" effort="100" velocity="100"/>
 		</joint>
-		<!-- WARNING: LIMITS NOT CORRECT -->
 		<joint name="${prefix}joint_3" type="revolute">
 			<parent link="${prefix}link_2"/>
 			<child link="${prefix}link_3"/>
 			<axis xyz="0 0 1"/>
 			<origin xyz="0.039 0 0" rpy="0 0 0"/>
-			<limit lower="0" upper="3.1416" effort="100" velocity="100"/>
+			<limit lower="-1.2217" upper="-0.0523" effort="100" velocity="100"/>
 		</joint>
 		<!-- end of joint list -->
 	</xacro:macro>


### PR DESCRIPTION
The upper and lower limits for the joints were identified with the
robotiq_joint_state_publisher for the s model by moving to different poses via the SModelSimpleController.py.
This was necessary in order to use moveit with this urdf out of the box.
