### PR TITLE
Add queue_size to SModelRobotInput publisher

### DIFF
--- a/robotiq_s_model_control/nodes/SModelTcpNode.py
+++ b/robotiq_s_model_control/nodes/SModelTcpNode.py
@@ -62,7 +62,7 @@ def mainLoop(address):
     rospy.init_node('robotiqSModel')
 
     #The Gripper status is published on the topic named 'SModelRobotInput'
-    pub = rospy.Publisher('SModelRobotInput', inputMsg.SModel_robot_input)
+    pub = rospy.Publisher('SModelRobotInput', inputMsg.SModel_robot_input, queue_size=1)
 
     #The Gripper command is received from the topic named 'SModelRobotOutput'
     rospy.Subscriber('SModelRobotOutput', outputMsg.SModel_robot_output, gripper.refreshCommand)    


### PR DESCRIPTION
The publisher should be created with an explicit keyword argument
'queue_size'. The queue_size is set to 1, because every message contains
all needed informations.
