### PR TITLE
Moved publishers and service for force_torque_sensor to private namespace

### DIFF
--- a/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
+++ b/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
@@ -173,9 +173,10 @@ int main(int argc, char **argv)
 		wait_for_other_connection();
 	}
 	
-	ros::Publisher sensor_pub = n.advertise<robotiq_force_torque_sensor::ft_sensor>("robotiq_force_torque_sensor", 512);
-	ros::Publisher wrench_pub = n.advertise<geometry_msgs::WrenchStamped>("robotiq_force_torque_wrench", 512);
-	ros::ServiceServer service = n.advertiseService("robotiq_force_torque_sensor_acc", receiverCallback);
+    ros::NodeHandle nh_private("~");
+    ros::Publisher sensor_pub = nh_private.advertise<robotiq_force_torque_sensor::ft_sensor>("sensor", 512);
+    ros::Publisher wrench_pub = nh_private.advertise<geometry_msgs::WrenchStamped>("wrench", 512);
+    ros::ServiceServer service = nh_private.advertiseService("sensor_acc", receiverCallback);
 
 	//std_msgs::String msg;
 	geometry_msgs::WrenchStamped wrenchMsg;

--- a/robotiq_force_torque_sensor/nodes/rq_test_sensor.cpp
+++ b/robotiq_force_torque_sensor/nodes/rq_test_sensor.cpp
@@ -68,8 +68,9 @@ int main(int argc, char **argv)
 
 	ros::NodeHandle n;
 
-	ros::ServiceClient client = n.serviceClient<robotiq_force_torque_sensor::sensor_accessor>("robotiq_force_torque_sensor_acc");
-	ros::Subscriber sub1 = n.subscribe("robotiq_force_torque_sensor",100,reCallback);
+    std::string node_name = "/robotiq_force_torque_sensor";
+    ros::ServiceClient client = n.serviceClient<robotiq_force_torque_sensor::sensor_accessor>(node_name+"/sensor_acc");
+    ros::Subscriber sub1 = n.subscribe(node_name+"/sensor", 100, reCallback);
 
 	robotiq_force_torque_sensor::sensor_accessor srv;
 


### PR DESCRIPTION
So far, the publishers and the service have been in the global namespace. This does not work for multiple sensors and also make configuring interfaces harder as you have to pass the name of the publishers and the service if the node should be able to use both. With the current version, an interface node only gets the node name and can either add the names or use topictools to find the correct topic names. 