### PR TITLE
Replaced string-based interface with numerical constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+CATKIN_IGNORE
+*.user

--- a/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_state.h
+++ b/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_state.h
@@ -61,6 +61,8 @@ enum rq_sensor_state_values
 
 INT_8 rq_sensor_state(unsigned int max_retries);
 void rq_state_get_command(INT_8 const * const name, INT_8 * const  value);
+bool rq_state_get_command(INT_8 command, INT_8 * const  value);
+
 void rq_state_do_zero_force_flag(void);
 enum rq_sensor_state_values rq_sensor_get_current_state(void);
 bool rq_state_got_new_message(void);

--- a/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_state.h
+++ b/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_state.h
@@ -48,6 +48,20 @@
 #include <stdbool.h>
 
 
+/// (Re-)Definition of ROS-Service to keep this driver ROS-free
+/// Update after changes to srv/sensor_accessor.srv
+namespace SensorAccessor
+{
+  enum Command
+  {
+	 GET_SERIAL_NUMBER = 1,
+	 GET_FIRMWARE_VERSION = 2,
+	 GET_PRODUCTION_YEAR = 4,
+	 SET_ZERO = 8
+  };
+}
+
+
 enum rq_sensor_state_values 
 {
 	RQ_STATE_INIT,         ///< State that initialize the com. with the sensor

--- a/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
+++ b/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
@@ -50,11 +50,53 @@
 #include "robotiq_force_torque_sensor/ft_sensor.h"
 #include "robotiq_force_torque_sensor/sensor_accessor.h"
 
+typedef robotiq_force_torque_sensor::sensor_accessor::Request Request;
+
 static void decode_message_and_do(INT_8 const  * const buff, INT_8 * const ret);
+static void decode_message_and_do(robotiq_force_torque_sensor::sensor_accessor::Request& req,
+								  robotiq_force_torque_sensor::sensor_accessor::Response& res);
+
 static void wait_for_other_connection(void);
 static int max_retries_(100);
 
 ros::Publisher sensor_pub_acc;
+
+/**
+ * @brief decode_message_and_do Decode the message received and do the associated action
+ * @param req
+ * @param res
+ */
+static void decode_message_and_do(robotiq_force_torque_sensor::sensor_accessor::Request& req,
+								  robotiq_force_torque_sensor::sensor_accessor::Response& res)
+{
+	if (req.command_id == Request::COMMAND_SET_ZERO)
+	{
+		ROS_INFO("Zeroing Sensor");
+		rq_state_do_zero_force_flag();
+		res.success = true;
+		res.res = "Done";
+		return;
+	}
+
+	if (req.command_id != Request::COMMAND_GET_FIRMWARE_VERSION &&
+		req.command_id != Request::COMMAND_GET_PRODUCTION_YEAR &&
+		req.command_id != Request::COMMAND_GET_SERIAL_NUMBER)
+	{
+		ROS_WARN("Unsupported command_id '%i', should be in [%i, %i, %i]",
+			 req.command_id,
+			 Request::COMMAND_GET_SERIAL_NUMBER,
+			 Request::COMMAND_GET_FIRMWARE_VERSION,
+			 Request::COMMAND_GET_PRODUCTION_YEAR);
+		res.success = false;
+		res.res = "Unsupported command_id";
+		return;
+	}
+
+	INT_8 buffer[512];
+	res.success = rq_state_get_command(req.command_id, buffer);
+	res.res = buffer;
+}
+
 
 /**
  * \brief Decode the message received and do the associated action
@@ -91,11 +133,20 @@ static void decode_message_and_do(INT_8 const  * const buff, INT_8 * const ret)
 bool receiverCallback(robotiq_force_torque_sensor::sensor_accessor::Request& req,
 	robotiq_force_torque_sensor::sensor_accessor::Response& res)
 {
-	ROS_INFO("I heard: [%s]",req.command.c_str());
-	INT_8 buffer[512];
-	decode_message_and_do((char*)req.command.c_str(), buffer);
-	res.res = buffer;
-	ROS_INFO("I send: [%s]", res.res.c_str());
+	/// Support for old string-based interface
+	if (req.command.length())
+	{
+		ROS_WARN("Usage of command-string is deprecated, please use the numeric command_id");
+		ROS_INFO("I heard: [%s]",req.command.c_str());
+		INT_8 buffer[512];
+		decode_message_and_do((char*)req.command.c_str(), buffer);
+		res.res = buffer;
+		ROS_INFO("I send: [%s]", res.res.c_str());
+		return true;
+	}
+
+	/// New interface with numerical commands
+	decode_message_and_do(req, res);
 	return true;
 }
 

--- a/robotiq_force_torque_sensor/nodes/rq_test_sensor.cpp
+++ b/robotiq_force_torque_sensor/nodes/rq_test_sensor.cpp
@@ -77,7 +77,13 @@ int main(int argc, char **argv)
 	while (ros::ok())
 	{
 	if(count == 10000000){
-		srv.request.command = "SET ZRO";
+
+		/// Deprecated Interface
+		// srv.request.command = "SET ZRO";
+
+		/// New Interface with numerical commands
+		srv.request.command_id = srv.request.COMMAND_SET_ZERO;
+
 		if(client.call(srv)){
 			ROS_INFO("ret: %s", srv.response.res.c_str());
 		}

--- a/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
+++ b/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
@@ -199,8 +199,8 @@ float rq_state_get_received_data(UINT_8 i)
 /**
  * \fn bool rq_state_get_command(INT_8 command, char *value)
  * \brief Gets the value of high level information from the sensor
- * \param command has to be in [1,2,4] corresponding to SerialNumber, FirmwareVersion and ProductionYear
- * \param value A string
+ * \param command has to be in [1, 2, 4, 8] corresponding to SerialNumber, FirmwareVersion and ProductionYear, Reset
+ * \param value return string with requested Data
  * \return true iff command is valid
  */
 bool rq_state_get_command(INT_8 command, INT_8 * const  value)
@@ -216,9 +216,13 @@ bool rq_state_get_command(INT_8 command, INT_8 * const  value)
 	case 4:
 		rq_com_get_str_production_year( value);
 		break;
-	default:
-		return false;
+	case 8:
+		rq_state_do_zero_force_flag();
+		strcpy(value, "Done");
 		break;
+	default:
+		strcpy(value, "Unsupported command_id");
+		return false;
 	}
 	return true;
 }

--- a/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
+++ b/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
@@ -207,16 +207,16 @@ bool rq_state_get_command(INT_8 command, INT_8 * const  value)
 {
 	/// values correnspond to constants in sensor_accessor.srv
 	switch (command) {
-	case 1:
+	case SensorAccessor::GET_SERIAL_NUMBER:
 		rq_com_get_str_serial_number( value);
 		break;
-	case 2:
+	case SensorAccessor::GET_FIRMWARE_VERSION:
 		rq_com_get_str_firmware_version( value);
 		break;
-	case 4:
+	case SensorAccessor::GET_PRODUCTION_YEAR:
 		rq_com_get_str_production_year( value);
 		break;
-	case 8:
+	case SensorAccessor::SET_ZERO:
 		rq_state_do_zero_force_flag();
 		strcpy(value, "Done");
 		break;

--- a/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
+++ b/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
@@ -194,6 +194,36 @@ float rq_state_get_received_data(UINT_8 i)
 	}
 }
 
+
+
+/**
+ * \fn bool rq_state_get_command(INT_8 command, char *value)
+ * \brief Gets the value of high level information from the sensor
+ * \param command has to be in [1,2,4] corresponding to SerialNumber, FirmwareVersion and ProductionYear
+ * \param value A string
+ * \return true iff command is valid
+ */
+bool rq_state_get_command(INT_8 command, INT_8 * const  value)
+{
+	/// values correnspond to constants in sensor_accessor.srv
+	switch (command) {
+	case 1:
+		rq_com_get_str_serial_number( value);
+		break;
+	case 2:
+		rq_com_get_str_firmware_version( value);
+		break;
+	case 4:
+		rq_com_get_str_production_year( value);
+		break;
+	default:
+		return false;
+		break;
+	}
+	return true;
+}
+
+
 /**
  * \fn int rq_state_get_command(char* name, char *value)
  * \brief Gets the value of high level information from the sensor

--- a/robotiq_force_torque_sensor/srv/sensor_accessor.srv
+++ b/robotiq_force_torque_sensor/srv/sensor_accessor.srv
@@ -1,3 +1,9 @@
-string command
+uint8 COMMAND_GET_SERIAL_NUMBER=1
+uint8 COMMAND_GET_FIRMWARE_VERSION=2
+uint8 COMMAND_GET_PRODUCTION_YEAR=4
+uint8 COMMAND_SET_ZERO=8
+uint8 command_id
+string command  # deprecated, please use command_id with a value of COMMAND_*
 ---
+bool success
 string res


### PR DESCRIPTION
…so that a user does not have to remember commands like 'GET PYE'. String-commands are still supported but generate a ROS_WARN

https://github.com/ros-industrial/robotiq/issues/92
