### PR TITLE
add launch/robotiq_gripper_upload.launch

### DIFF
--- a/robotiq_s_model_visualization/launch/robotiq_gripper_upload.launch
+++ b/robotiq_s_model_visualization/launch/robotiq_gripper_upload.launch
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find robotiq_s_model_visualization)/cfg/robotiq_hand.urdf.xacro'" />
+
+</launch>


### PR DESCRIPTION
Simple copy/paste of the robotiq_s_model_visualization/launch/robotiq_gripper_upload.launch from groovy to the jade branch. This PR fixes issue #94. This PR addresses @gavanderhoorn's comment "Could we retain using a launch file for setting robot_description?"

Sorry, @shaun-edwards, i tried to edit your PR #96 but i wasn't allowed.  

I didn't test this.