### PR TITLE
Compile with Gazebo 7 dependency

### DIFF
--- a/robotiq_s_model_articulated_gazebo_plugins/CMakeLists.txt
+++ b/robotiq_s_model_articulated_gazebo_plugins/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_s_model_articulated_gazebo_plugins)
+set (CMAKE_CXX_STANDARD 11)
 
 find_package(catkin REQUIRED COMPONENTS std_msgs gazebo_plugins actionlib tf image_transport control_msgs trajectory_msgs geometry_msgs sensor_msgs roscpp gazebo_ros robotiq_s_model_articulated_msgs)
 

--- a/robotiq_s_model_articulated_gazebo_plugins/CMakeLists.txt
+++ b/robotiq_s_model_articulated_gazebo_plugins/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_s_model_articulated_gazebo_plugins)
-set (CMAKE_CXX_STANDARD 11)
 
 find_package(catkin REQUIRED COMPONENTS std_msgs gazebo_plugins actionlib tf image_transport control_msgs trajectory_msgs geometry_msgs sensor_msgs roscpp gazebo_ros robotiq_s_model_articulated_msgs)
 
@@ -19,6 +18,8 @@ link_directories(
 catkin_package(
    DEPENDS gazebo_plugins gazebo_ros robotiq_s_model_articulated_msgs roscpp
 )
+
+add_compile_options(-std=c++11)
 
 add_library(RobotiqHandPlugin src/RobotiqHandPlugin.cpp)
 set_target_properties(RobotiqHandPlugin PROPERTIES LINK_FLAGS "${ld_flags}")

--- a/robotiq_s_model_articulated_gazebo_plugins/include/robotiq_s_model_articulated_gazebo_plugins/RobotiqHandPlugin.h
+++ b/robotiq_s_model_articulated_gazebo_plugins/include/robotiq_s_model_articulated_gazebo_plugins/RobotiqHandPlugin.h
@@ -173,18 +173,18 @@ class RobotiqHandPlugin : public gazebo::ModelPlugin
 
   /// \brief Velocity tolerance. Below this value we assume that the joint is
   /// stopped (rad/s).
-  private: static const double VelTolerance = 0.002;
+  private: static constexpr double VelTolerance = 0.002;
 
   /// \brief Position tolerance. If the difference between target position and
   /// current position is within this value we'll conclude that the joint
   /// reached its target (rad).
-  private: static const double PoseTolerance = 0.002;
+  private: static constexpr double PoseTolerance = 0.002;
 
   /// \brief Min. joint speed (rad/s). Finger is 125mm and tip speed is 22mm/s.
-  private: static const double MinVelocity = 0.176;
+  private: static constexpr double MinVelocity = 0.176;
 
   /// \brief Max. joint speed (rad/s). Finger is 125mm and tip speed is 110mm/s.
-  private: static const double MaxVelocity = 0.88;
+  private: static constexpr double MaxVelocity = 0.88;
 
   /// \brief Default topic name for sending control updates to the left hand.
   private: static const std::string DefaultLeftTopicCommand;


### PR DESCRIPTION
This PR enables c++11 standard which is required when compiling with Gazebo 7.

If the compiler option is not set the compile process fails with:
```
[ 83%] Built target moveit_move_group_default_capabilities
In file included from /usr/include/c++/5/random:35:0,
                from /usr/include/ignition/math2/ignition/math/Rand.hh:20,
                from /usr/include/ignition/math2/ignition/math.hh:18,
                from /usr/include/sdformat-4.0/sdf/Param.hh:34,
                from /usr/include/sdformat-4.0/sdf/Element.hh:24,
                from /usr/include/sdformat-4.0/sdf/sdf.hh:5,
                from /usr/include/gazebo-7/gazebo/common/Plugin.hh:42,
                from /homeL/demo/ros/src/upstream/robotiq/robotiq_s_model_articulated_gazebo_plugins/src/RobotiqHandPlugin.cpp:35:
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^
```

Additionally all thereby invalid `const double` expressions are changed to `constexpr`.