### PR TITLE
Support for specifying device node name on Linux.

### DIFF
--- a/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_com.h
+++ b/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_com.h
@@ -46,10 +46,12 @@
 #include "rq_int.h"
 #include <stdio.h>
  #include <stdbool.h>
+#include <string>
 
 #define MP_BUFF_SIZE    1024
 
-INT_8 rq_sensor_com(void);
+INT_8 rq_sensor_com();
+INT_8 rq_sensor_com(const std::string&);
 void rq_sensor_com_read_info_high_lvl(void);
 INT_8 rq_com_start_stream(void);
 void rq_com_listen_stream(void);

--- a/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_state.h
+++ b/robotiq_force_torque_sensor/include/robotiq_force_torque_sensor/rq_sensor_state.h
@@ -46,6 +46,7 @@
 
 #include "rq_int.h"
 #include <stdbool.h>
+#include <string>
 
 
 /// (Re-)Definition of ROS-Service to keep this driver ROS-free
@@ -62,18 +63,19 @@ namespace SensorAccessor
 }
 
 
-enum rq_sensor_state_values 
+enum rq_sensor_state_values
 {
 	RQ_STATE_INIT,         ///< State that initialize the com. with the sensor
 	RQ_STATE_READ_INFO,    ///< State that reads the firmware version,
 	                       ///< serial number and production year
 	RQ_STATE_START_STREAM, ///< State that start the sensor in streaming
 	                       ///< mode
-	RQ_STATE_RUN           ///< State that reads the streaming data from 
+	RQ_STATE_RUN           ///< State that reads the streaming data from
 		                   ///< the sensor
 };
 
 INT_8 rq_sensor_state(unsigned int max_retries);
+INT_8 rq_sensor_state(unsigned int max_retries, const std::string& ftdi_id);
 void rq_state_get_command(INT_8 const * const name, INT_8 * const  value);
 bool rq_state_get_command(INT_8 command, INT_8 * const  value);
 

--- a/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
+++ b/robotiq_force_torque_sensor/nodes/rq_sensor.cpp
@@ -51,13 +51,8 @@
 #include "robotiq_force_torque_sensor/sensor_accessor.h"
 
 typedef robotiq_force_torque_sensor::sensor_accessor::Request Request;
-
-static void decode_message_and_do(INT_8 const  * const buff, INT_8 * const ret);
-static bool decode_message_and_do(robotiq_force_torque_sensor::sensor_accessor::Request& req,
-								  robotiq_force_torque_sensor::sensor_accessor::Response& res);
-
-static void wait_for_other_connection(void);
 static int max_retries_(100);
+std::string ftdi_id;
 
 ros::Publisher sensor_pub_acc;
 
@@ -106,7 +101,7 @@ static void decode_message_and_do(INT_8 const  * const buff, INT_8 * const ret)
 
 	strncpy(get_or_set, &buff[0], 3);
 	strncpy(nom_var, &buff[4], strlen(buff) -3);
-	
+
 	if(strstr(get_or_set, "GET"))
 	{
 		rq_state_get_command(nom_var, ret);
@@ -141,11 +136,21 @@ bool receiverCallback(robotiq_force_torque_sensor::sensor_accessor::Request& req
 	return true;
 }
 
+static INT_8 sensor_state_machine()
+{
+    if (ftdi_id.empty())
+    {
+        return rq_sensor_state(max_retries_);
+    }
+
+    return rq_sensor_state(max_retries_, ftdi_id);
+}
+
 /**
  * \fn static void wait_for_other_connection()
  * \brief Each second, checks for a sensor that has been connected
  */
-static void wait_for_other_connection(void)
+static void wait_for_other_connection()
 {
 	INT_8 ret;
 
@@ -154,8 +159,8 @@ static void wait_for_other_connection(void)
 		ROS_INFO("Waiting for sensor connection...");
 		usleep(1000000);//Attend 1 seconde.
 
-		ret = rq_sensor_state(max_retries_);
-		if(ret == 0)
+        ret = sensor_state_machine();
+        if(ret == 0)
 		{
 			ROS_INFO("Sensor connected!");
 			break;
@@ -189,32 +194,41 @@ int main(int argc, char **argv)
 	ros::init(argc, argv, "robotiq_force_torque_sensor");
 	ros::NodeHandle n;
 	ros::param::param<int>("~max_retries", max_retries_, 100);
+    ros::param::get("~serial_id", ftdi_id);
+    if (!ftdi_id.empty())
+    {
+        ROS_INFO("Trying to connect to a sensor at /dev/%s", ftdi_id.c_str());
+    }
+    else
+    {
+        ROS_INFO("No device filename specified. Will attempt to discover Robotiq force torque sensor.");
+    }
 
 	INT_8 bufStream[512];
 	robotiq_force_torque_sensor::ft_sensor msgStream;
-	INT_8 ret; 
+	INT_8 ret;
 
 	//If we can't initialize, we return an error
-	ret = rq_sensor_state(max_retries_);
+	ret = sensor_state_machine();
 	if(ret == -1)
 	{
 		wait_for_other_connection();
 	}
 
 	//Reads basic info on the sensor
-	ret = rq_sensor_state(max_retries_);
+	ret = sensor_state_machine();
 	if(ret == -1)
 	{
 		wait_for_other_connection();
 	}
 
 	//Starts the stream
-	ret = rq_sensor_state(max_retries_);
+	ret = sensor_state_machine();
 	if(ret == -1)
 	{
 		wait_for_other_connection();
 	}
-	
+
 	ros::Publisher sensor_pub = n.advertise<robotiq_force_torque_sensor::ft_sensor>("robotiq_force_torque_sensor", 512);
 	ros::Publisher wrench_pub = n.advertise<geometry_msgs::WrenchStamped>("robotiq_force_torque_wrench", 512);
 	ros::ServiceServer service = n.advertiseService("robotiq_force_torque_sensor_acc", receiverCallback);
@@ -226,10 +240,9 @@ int main(int argc, char **argv)
 	ROS_INFO("Starting Sensor");
 	while(ros::ok())
 	{
-		ret = rq_sensor_state(max_retries_);
-
-		if(ret == -1)
-		{
+        ret = sensor_state_machine();
+        if (ret == -1)
+        {
 			wait_for_other_connection();
 		}
 

--- a/robotiq_force_torque_sensor/src/rq_sensor_com.cpp
+++ b/robotiq_force_torque_sensor/src/rq_sensor_com.cpp
@@ -135,9 +135,22 @@ HANDLE hSerial;
 /**
  * \fn void rq_sensor_com(void)
  * \brief Discovers and initialize the communication with the sensor
- * \details The functions loops  through all the serial com ports 
+ * \details The functions loops  through all the serial com ports
  *          and polls them to discover the sensor
  */
+
+
+INT_8 rq_sensor_com(const std::string& ftdi_id)
+{
+    UINT_8 device_found = 0;
+    device_found = rq_com_identify_device(ftdi_id.c_str());
+    if (device_found == 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
 INT_8 rq_sensor_com()
 {
 #ifdef __unix__ //For Unix
@@ -150,18 +163,18 @@ INT_8 rq_sensor_com()
 	if ((dir = opendir("/sys/class/tty/")) == NULL)
 	{
 		return -1;
-	}
+    }
 
-	//Loops through the files in the /sys/class/tty/ directory
-	while ((entrydirectory = readdir(dir)) != NULL && device_found == 0)
-	{
-		//Look for a serial device
-		if (strstr(entrydirectory->d_name, "ttyS") || 
-			strstr(entrydirectory->d_name, "ttyUSB"))
-		{
-			device_found = rq_com_identify_device(entrydirectory->d_name);
-		}
-	}
+    //Loops through the files in the /sys/class/tty/ directory
+    while ((entrydirectory = readdir(dir)) != NULL && device_found == 0)
+    {
+        //Look for a serial device
+        if (strstr(entrydirectory->d_name, "ttyS") ||
+            strstr(entrydirectory->d_name, "ttyUSB"))
+        {
+            device_found = rq_com_identify_device(entrydirectory->d_name);
+        }
+    }
 
 	closedir(dir);
 
@@ -322,7 +335,7 @@ void rq_com_listen_stream(void)
 	static INT_32 last_byte = 0;
 	static INT_32 new_message = 0;
 	INT_32 i = 0;
-	INT_32 j = 0;    
+	INT_32 j = 0;
 
 	//Capture and store the current value of the sensor and use it to
 	//zero subsequent sensor values
@@ -384,8 +397,8 @@ void rq_com_listen_stream(void)
 	memset( rq_com_snd_buff, 0, sizeof(rq_com_snd_buff));
 
 	//If there is enough characters,...
-	if(rq_com_rcv_len2 >= 16 && rq_com_rcv_len >= 1) 
-	{        
+	if(rq_com_rcv_len2 >= 16 && rq_com_rcv_len >= 1)
+	{
 		//Search for a valid stream message in the buffer
 		for(i = rq_com_rcv_len2 - 16; i >= 0; i--)
 		{
@@ -469,7 +482,7 @@ static void rq_com_send_jam_signal(void)
 static void rq_com_stop_stream_after_boot(void)
 {
 	static INT_32 counter = 0;
-	
+
 	while(rq_com_stream_detected)
 	{
 		counter++;
@@ -536,7 +549,7 @@ static INT_8 rq_com_send_fc_03(UINT_16 base, UINT_16 n, UINT_16 * const data)
 	UINT_8 bytes_read = 0;
 	INT_32 i = 0;
 	INT_32 cpt = 0;
-	UINT_8 data_request[n]; 
+	UINT_8 data_request[n];
 	UINT_16 retries = 0;
 
 	//precondition, null pointer
@@ -713,7 +726,7 @@ static INT_32 rq_com_write_port(UINT_8 const * const buf, UINT_32 buf_len)
 
 /**
  * \fn static UINT_16 rq_com_compute_crc(UINT_8 * adr, INT_32 length )
- * \param adr, Address of the first byte 
+ * \param adr, Address of the first byte
  * \param length Length of the buffer on which the crc is computed
  * \return Value of the crc
  */
@@ -744,7 +757,7 @@ static UINT_16 rq_com_compute_crc(UINT_8 const * adr, INT_32 length )
 		}
 
 		k=0;
-		
+
 		//Tant que le byte n'est pas complété
 		while (k < 8)
 		{
@@ -757,15 +770,15 @@ static UINT_16 rq_com_compute_crc(UINT_8 const * adr, INT_32 length )
 			{
 				CRC_calc >>= 1;			//Shift de 1 bit vers la droite
 			}
-	
+
 			k++;
 		}
-	
+
 		//Incrémente l'adresse et le compteur d'adresse
 		adr++;
 		j++;
 	}
-	
+
 	return CRC_calc;
 }
 
@@ -782,19 +795,19 @@ static void rq_com_send_fc_03_request(UINT_16 base, UINT_16 n)
 	UINT_8 reg[2];
 	UINT_8 words[2];
 	UINT_16 CRC;
-	
+
 	//Si le nombre de registre est impair
 	if(n % 2 != 0)
 	{
 		n += 1;
 	}
-	
+
 	//Scinder en LSB et MSB
 	reg[0]   = (UINT_8)(base >> 8); //MSB to the left
 	reg[1]   = (UINT_8)(base & 0x00FF); //LSB to the right
 	words[0] = (UINT_8)((n/2) >> 8); //MSB to the left
 	words[1] = (UINT_8)((n/2) & 0x00FF); //LSB to the right
-	
+
 	//Build the request
 	buf[length++] = 9; //slave address
 	buf[length++] = 3;
@@ -802,14 +815,14 @@ static void rq_com_send_fc_03_request(UINT_16 base, UINT_16 n)
 	buf[length++] = reg[1];
 	buf[length++] = words[0];
 	buf[length++] = words[1];
-	
+
 	//CRC computation
 	CRC = rq_com_compute_crc(buf, length);
-	
+
 	//Append the crc
 	buf[length++] = (UINT_8)(CRC & 0x00FF);
 	buf[length++] = (UINT_8)(CRC >> 8);
-	
+
 	//Send the request
 	rq_com_write_port(buf, length);
 }
@@ -830,7 +843,7 @@ static INT_32 rq_com_wait_for_fc_03_echo(UINT_8 * const data)
 	UINT_16 CRC = 0;
 	INT_32 j = 0;
 	INT_32 ret = rq_com_read_port(&buf[length], MP_BUFF_SIZE - length);
-	
+
 	if(ret != -1)
 	{
 		length = length + ret;
@@ -852,9 +865,9 @@ static INT_32 rq_com_wait_for_fc_03_echo(UINT_8 * const data)
 	{
 		counter_no_new_data = 0;
 	}
-	
+
 	old_length = length;
-	
+
 	if(length > 0)
 	{
 		//If there is not enough data, return
@@ -879,7 +892,7 @@ static INT_32 rq_com_wait_for_fc_03_echo(UINT_8 * const data)
 			}
 		}
 		CRC = rq_com_compute_crc(buf, length - 2);
-		
+
 		//Verifies the crc and the slave ID
 		if(CRC != (UINT_16)((buf[length - 1] * 256) + (buf[length - 2])))
 		{
@@ -891,20 +904,20 @@ static INT_32 rq_com_wait_for_fc_03_echo(UINT_8 * const data)
 		else
 		{
 			n = buf[2];
-			
+
 			//Writes the bytes to the return buffer
 			for(j = 0; j < n; j++)
 			{
 				data[j] = buf[j + 3];
 			}
-			
+
 			//Clears the buffer
 			buf[0] = 0;
 			length = 0;
 			return n;
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -931,7 +944,7 @@ static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const * cons
 	{
 		return;
 	}
-	
+
 	//Manage if the number of bytes to write is odd or even
 	if(n %2 != 0)
 	{
@@ -941,14 +954,14 @@ static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const * cons
 	{
 		n2 = n;
 	}
-	
+
 	//Split the address and the number of bytes between MSB ans LSB
 	reg[0]   = (UINT_8)(base >> 8);       //MSB to the left
 	reg[1]   = (UINT_8)(base & 0x00FF);   //LSB to the right
 	words[0] = (UINT_8)((n2/2) >> 8);     //MSB to the left
 	words[1] = (UINT_8)((n2/2) & 0x00FF); //LSB to the right
-	
-	
+
+
 	//Build the query
 	buf[length++] = 9; //slave address
 	buf[length++] = 16;
@@ -957,24 +970,24 @@ static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const * cons
 	buf[length++] = words[0];
 	buf[length++] = words[1];
 	buf[length++] = n2;
-	
+
 	//Copy data to the send buffer
 	for(i = 0; i < n; i++)
 	{
 		buf[length++] = data[i];
 	}
-	
+
 	if(n != n2)
 	{
 		buf[length++] = 0;
 	}
-	
+
 	CRC = rq_com_compute_crc(buf, length);
-	
+
 	//Append the crc to the query
 	buf[length++] = (UINT_8)(CRC & 0x00FF);
 	buf[length++] = (UINT_8)(CRC >> 8);
-	
+
 	//Send the query
 	rq_com_write_port(buf, length);
 }
@@ -1121,7 +1134,7 @@ float rq_com_get_received_data(UINT_8 i)
 /**
  * \brief Returns true if a new valid stream message has been decoded and
  *        is available.
- * \details When this function is called, the variable that indicates if a 
+ * \details When this function is called, the variable that indicates if a
 			new message is available is set to false even if the message
 			hasn't beed read.
  */
@@ -1143,7 +1156,7 @@ void rq_com_do_zero_force_flag()
 }
 
 /**
- * \brief close the serial port. 
+ * \brief close the serial port.
  * \warning Only valid under Windows.
  */
 void stop_connection()
@@ -1170,9 +1183,9 @@ static UINT_8 rq_com_identify_device(INT_8 const * const d_name)
 	strcpy(port_com, dirParent);
 	fd_connexion = open(port_com, O_RDWR | O_NOCTTY | O_NDELAY | O_EXCL);
 
-	//The serial port is open
-	if(fd_connexion != -1)
-	{
+    //The serial port is open
+    if (fd_connexion != -1)
+    {
 		if(set_com_attribs(fd_connexion,B19200) != -1)
 		{
 			//Try connecting to the sensor
@@ -1181,7 +1194,7 @@ static UINT_8 rq_com_identify_device(INT_8 const * const d_name)
 				return 1;
 			}
 		}
-		
+
 		//The device is identified, close the connection
 		close(fd_connexion);
 	}

--- a/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
+++ b/robotiq_force_torque_sensor/src/rq_sensor_state.cpp
@@ -53,6 +53,7 @@ static enum rq_sensor_state_values current_state = RQ_STATE_INIT;
 ///////////////////
 //Private functions
 static INT_8 rq_state_init_com();
+static INT_8 rq_state_init_com(const std::string& ftdi_id);
 static void rq_state_read_info_high_lvl();
 static void rq_state_start_stream();
 static void rq_state_run(unsigned int max_retries);
@@ -65,17 +66,17 @@ static void rq_state_run(unsigned int max_retries);
  * \brief Manages the states of the sensor driver
  * \returns -1 if an error occurs, 0 otherwise
  */
-INT_8 rq_sensor_state(unsigned int max_retries)
+INT_8 rq_sensor_state(unsigned int max_retries, const std::string& ftdi_id)
 {
 	INT_8 ret;
 
 	switch (current_state)
 	{
 	case RQ_STATE_INIT:
-		ret = rq_state_init_com();
+		ret = rq_state_init_com(ftdi_id);
 		if(ret == -1)
 		{
-			return -1;
+            return -1;
 		}
 		break;
 
@@ -100,26 +101,82 @@ INT_8 rq_sensor_state(unsigned int max_retries)
 	return 0;
  }
 
-/**
+ /**
+ * \fn void rq_sensor_state(void)
+ * \brief Manages the states of the sensor driver
+ * \returns -1 if an error occurs, 0 otherwise
+ */
+ INT_8 rq_sensor_state(unsigned int max_retries)
+ {
+     INT_8 ret;
+
+     switch (current_state)
+     {
+     case RQ_STATE_INIT:
+         ret = rq_state_init_com();
+         if (ret == -1)
+         {
+             return -1;
+         }
+         break;
+
+     case RQ_STATE_READ_INFO:
+         rq_state_read_info_high_lvl();
+         break;
+
+     case RQ_STATE_START_STREAM:
+         rq_state_start_stream();
+         break;
+
+     case RQ_STATE_RUN:
+         rq_state_run(max_retries);
+         break;
+
+     default:
+         printf("rq_state(): Unknown error\r\n");
+         return -1;
+         break;
+
+     }
+     return 0;
+ }
+
+ /**
  * \fn void rq_state_init_com(void)
  * \brief Initialize communication with the sensor and set the
  *        next state to \ref RQ_STATE_READ_INFO
  */
-static INT_8 rq_state_init_com()
-{
-	if(rq_sensor_com() == -1)
-	{
-		return -1;
-	}
+ static INT_8 rq_state_init_com()
+ {
+     if (rq_sensor_com() == -1)
+     {
+         return -1;
+     }
 
-	current_state = RQ_STATE_READ_INFO;
-	return 0;
+     current_state = RQ_STATE_READ_INFO;
+     return 0;
+ }
+
+ /**
+ * \fn void rq_state_init_com(const std::string& ftdi_id)
+ * \brief Initialize communication with the sensor at /dev/ftdi_id
+ *        and set the next state to \ref RQ_STATE_READ_INFO
+ */
+ static INT_8 rq_state_init_com(const std::string &ftdi_id)
+ {
+     if (rq_sensor_com(ftdi_id) == -1)
+     {
+         return -1;
+     }
+
+     current_state = RQ_STATE_READ_INFO;
+     return 0;
 }
 
 /**
  * \fn void rq_state_read_info_high_lvl(void)
  * \brief Reads the high level information from the
- *        sensor and set the next state to 
+ *        sensor and set the next state to
  *        \ref RQ_STATE_START_STREAM
  */
 static void rq_state_read_info_high_lvl()
@@ -231,7 +288,7 @@ bool rq_state_get_command(INT_8 command, INT_8 * const  value)
 /**
  * \fn int rq_state_get_command(char* name, char *value)
  * \brief Gets the value of high level information from the sensor
- * \param name the name of the information field. The value can be 
+ * \param name the name of the information field. The value can be
  *                either "SNU", "FMW" or "PYE"
  * \param value A string
  * \return 0 in case of succes, -1 otherwise


### PR DESCRIPTION
Extended existing API to include function overloads that take a string specifying device node name.
Use "serial_id" rosparam to lookup device node name but fallback to discovery behavior.