### PR TITLE
Fixed limits of the passive joints of the 2f_140

### DIFF
--- a/robotiq_arg2f_model_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
+++ b/robotiq_arg2f_model_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
@@ -141,7 +141,7 @@
       <parent link="${prefix}robotiq_arg2f_base_link" />
       <child link="${prefix}${fingerprefix}_inner_knuckle" />
       <axis xyz="1 0 0" />
-      <limit lower="0" upper="0.8757" velocity="2.0" effort="1000" />
+      <limit lower="-0.8757" upper="0" velocity="2.0" effort="1000" />
       <mimic joint="${prefix}finger_joint" multiplier="-1" offset="0" />
     </joint>
   </xacro:macro>
@@ -176,7 +176,7 @@
       <parent link="${prefix}robotiq_arg2f_base_link" />
       <child link="${prefix}right_outer_knuckle" />
       <axis xyz="1 0 0" />
-      <limit lower="0" upper="0.725" velocity="2.0" effort="1000" />
+      <limit lower="-0.725" upper="0" velocity="2.0" effort="1000" />
     <mimic joint="${prefix}finger_joint" multiplier="-1" offset="0" />
     </joint>
     <xacro:finger_joints prefix="${prefix}" fingerprefix="right" reflect="-1.0"/>


### PR DESCRIPTION
The inner_knuckle_joints and right_outer_knuckle_joint had the wrong limits. This is a problem when simulating the mimic joints using gazebo plugins such as the one in https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.