### PR TITLE
readme: add support level badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Robotiq
 
+[![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
+
 [ROS-Industrial][] robotiq meta-package.  See the [ROS wiki][] page for more information.  
 
 ## Contents


### PR DESCRIPTION
As per subject.

Gives more visibility to the fact that Robotiq doesn't officially support this repository anymore.
