### PR TITLE
Updating all references to the maintainer email

### DIFF
--- a/robotiq/package.xml
+++ b/robotiq/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq</name>
   <version>1.0.0</version>
   <description>ROS drivers for Robotiq Adaptive Grippers and Robotiq Force Torque Sensor</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/robotiq</url>
 

--- a/robotiq_2f_140_gripper_visualization/package.xml
+++ b/robotiq_2f_140_gripper_visualization/package.xml
@@ -6,7 +6,7 @@
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/robotiq</url>
   <author email="ryan@rwsinnet.com">Ryan Sinnet</author>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/robotiq_2f_c2_gripper_visualization/package.xml
+++ b/robotiq_2f_c2_gripper_visualization/package.xml
@@ -10,7 +10,7 @@
     </p>
   </description>
 
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <author>Kel Guerin </author>
   <url type="website">http://ros.org/wiki/robotiq</url>
   <license>BSD</license>

--- a/robotiq_2f_gripper_action_server/package.xml
+++ b/robotiq_2f_gripper_action_server/package.xml
@@ -12,7 +12,7 @@
     </p>
   </description>
 
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <author>Jonathan Meyer</author>
   <license>BSD</license>
 

--- a/robotiq_2f_gripper_control/package.xml
+++ b/robotiq_2f_gripper_control/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_2f_gripper_control</name>
   <version>1.0.0</version>
   <description>Package to control a 2-Finger Gripper from Robotiq inc.</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/robotiq</url>
   <author>Nicolas Lauzier (Robotiq inc.)</author>

--- a/robotiq_3f_gripper_articulated_gazebo/package.xml
+++ b/robotiq_3f_gripper_articulated_gazebo/package.xml
@@ -4,7 +4,7 @@
   <version>1.0.0</version>
   <description>Launch files for spawning the Robotiq robotiq-3f-gripper articulated gripper</description>
 
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <author email="dash@clearpathrobotics.com">Devon Ash</author>
 
   <license>BSD</license>

--- a/robotiq_3f_gripper_articulated_gazebo_plugins/package.xml
+++ b/robotiq_3f_gripper_articulated_gazebo_plugins/package.xml
@@ -4,7 +4,7 @@
   <version>1.0.0</version>
   <description>The Robotiq gripper gazebo plugins package. Mainly a port from drcsim, to allow real Robotiq  gripper control and the plugin to have it work in Gazebo simulation. This package will provide the same interface to the gripper as one would have if they were interfacing with hardware. Porting code from software to reality should be seamless with this ROS interface now. </description>
 
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>Apache 2.0</license>
   <author email="dash@clearpathrobotics.com">Devon Ash</author>
   <author email="hsu@osrfoundation.com">John Hsu</author>

--- a/robotiq_3f_gripper_articulated_msgs/package.xml
+++ b/robotiq_3f_gripper_articulated_msgs/package.xml
@@ -4,7 +4,7 @@
   <version>1.0.0</version>
   <description>Messages for the robotiq_3f_gripper_articulated model.</description>
 
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>Apache 2.0</license>
   <author email="dash@clearpathrobotics.com">Devon Ash</author>
 

--- a/robotiq_3f_gripper_control/package.xml
+++ b/robotiq_3f_gripper_control/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_3f_gripper_control</name>
   <version>1.0.0</version>
   <description>Package to control a 3F gripper Gripper from Robotiq inc.</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/robotiq</url>
 

--- a/robotiq_3f_gripper_joint_state_publisher/package.xml
+++ b/robotiq_3f_gripper_joint_state_publisher/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_3f_gripper_joint_state_publisher</name>
   <version>1.0.0</version>
   <description>Publishes joint states of Robotiq 3F gripper</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>3-clause BSD</license>
   <author email="jack.thompson@utexas.edu">Jack Thompson</author>
 

--- a/robotiq_3f_gripper_visualization/package.xml
+++ b/robotiq_3f_gripper_visualization/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_3f_gripper_visualization</name>
   <version>1.0.0</version>
   <description>robotiq</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/robotiq</url>
   <author>Nicolas Lauzier (Robotiq inc.)</author>

--- a/robotiq_ethercat/README.md
+++ b/robotiq_ethercat/README.md
@@ -2,7 +2,7 @@
 This package provides an interface for interfacing with an ethercat network. With the current architecture, a single process is associated with a single network and that process must be aware of all slaves it will communicate with.
 
 ### Maintainer
-- Jean-Philippe Roberge (j-p.roberge@robotiq.com)
+- Jean-Philippe Roberge (ros@robotiq.com)
 
 ## Common Issues
 Please note:

--- a/robotiq_ethercat/package.xml
+++ b/robotiq_ethercat/package.xml
@@ -9,7 +9,7 @@
   </description>
 
   <author>Jonathan Meyer</author>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/robotiq_ft_sensor/include/robotiq_ft_sensor/rq_int.h
+++ b/robotiq_ft_sensor/include/robotiq_ft_sensor/rq_int.h
@@ -37,7 +37,7 @@
  *  \file rq_int.h
  *  \date June 19, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 #ifndef RQ_INT_H_

--- a/robotiq_ft_sensor/include/robotiq_ft_sensor/rq_sensor_com.h
+++ b/robotiq_ft_sensor/include/robotiq_ft_sensor/rq_sensor_com.h
@@ -37,7 +37,7 @@
  *  \file rq_sensor_com.h
  *  \date June 19, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 #ifndef RQ_SENSOR_COM_H

--- a/robotiq_ft_sensor/include/robotiq_ft_sensor/rq_sensor_state.h
+++ b/robotiq_ft_sensor/include/robotiq_ft_sensor/rq_sensor_state.h
@@ -37,7 +37,7 @@
  *  \file rq_sensor_state.h
  *  \date June 19, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 #ifndef RQ_SENSOR_STATE_H

--- a/robotiq_ft_sensor/nodes/rq_sensor.cpp
+++ b/robotiq_ft_sensor/nodes/rq_sensor.cpp
@@ -37,7 +37,7 @@
  * \file rq_sensor.cpp
  * \date July 14, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 #include <string.h>

--- a/robotiq_ft_sensor/nodes/rq_test_sensor.cpp
+++ b/robotiq_ft_sensor/nodes/rq_test_sensor.cpp
@@ -37,7 +37,7 @@
  * \file rq_test_sensor.cpp
  * \date July 14, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 #include "ros/ros.h"

--- a/robotiq_ft_sensor/package.xml
+++ b/robotiq_ft_sensor/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_ft_sensor</name>
   <version>1.0.0</version>
   <description>Package for reading data from a Robotiq Force Torque Sensor</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <author email="jsavoie20@gmail.com">Jonathan Savoie</author>
   <url type="website">http://ros.org/wiki/robotiq</url>
 

--- a/robotiq_ft_sensor/src/rq_sensor_com.cpp
+++ b/robotiq_ft_sensor/src/rq_sensor_com.cpp
@@ -37,7 +37,7 @@
  * \file rq_sensor_com.c
  * \date June 18, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 //////////

--- a/robotiq_ft_sensor/src/rq_sensor_state.cpp
+++ b/robotiq_ft_sensor/src/rq_sensor_state.cpp
@@ -37,7 +37,7 @@
  * \file rq_sensor_state.c
  * \date June 19, 2014
  *  \author Jonathan Savoie <jonathan.savoie@robotiq.com>
- *  \maintainer Nicolas Lauzier <nicolas@robotiq.com>
+ *  \maintainer Jean-Philippe Roberge <ros@robotiq.com>
  */
 
 //////////

--- a/robotiq_modbus_rtu/package.xml
+++ b/robotiq_modbus_rtu/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_modbus_rtu</name>
   <version>1.0.0</version>
   <description>A stack to communicate with Robotiq grippers using the Modbus RTU protocol</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/robotiq</url>
   <author>Nicolas Lauzier (Robotiq inc.)</author>

--- a/robotiq_modbus_tcp/package.xml
+++ b/robotiq_modbus_tcp/package.xml
@@ -3,7 +3,7 @@
   <name>robotiq_modbus_tcp</name>
   <version>1.0.0</version>
   <description>A stack to communicate with Robotiq grippers using the Modbus TCP protocol</description>
-  <maintainer email="j-p.roberge@robotiq.com">Jean-Philippe Roberge</maintainer>
+  <maintainer email="ros@robotiq.com">Jean-Philippe Roberge</maintainer>
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/robotiq</url>
   <author>Nicolas Lauzier (Robotiq inc.)</author>


### PR DESCRIPTION
This is a simple and minor PR, only to update the maintainer's email address. All references to the email are updated, that is, references to j-p.roberge@robotiq were simply updated to ros@robotiq.com. This was also done for proper documentation generation on ros.wiki, as this branch is soon going to be added to the indexer.