### PR TITLE
Connect gripper+FT via Bluetooth

### DIFF
--- a/robotiq_3f_gripper_control/nodes/Robotiq3FGripperRtuNode.py
+++ b/robotiq_3f_gripper_control/nodes/Robotiq3FGripperRtuNode.py
@@ -4,34 +4,34 @@
 ROS node for controling a Robotiq S-Model gripper using the Modbus RTU protocol.
 
 The script takes as an argument the device address of the gripper (e.g. /dev/ttyUSB0). Afterwards it acts like the
-SModelTcpNode.
+Robotiq3FGripperTcpNode.
 """
 
-import roslib; roslib.load_manifest('robotiq_s_model_control')
+import roslib; roslib.load_manifest('robotiq_3f_gripper_control')
 roslib.load_manifest('robotiq_modbus_tcp')
 import rospy
-import robotiq_s_model_control.baseSModel
+import robotiq_3f_gripper_control.baseRobotiq3FGripper
 import robotiq_modbus_rtu.comModbusRtu
 import os, sys
-from robotiq_s_model_control.msg import _SModel_robot_input  as inputMsg
-from robotiq_s_model_control.msg import _SModel_robot_output as outputMsg
+from robotiq_3f_gripper_control.msg import _Robotiq3FGripper_robot_input  as inputMsg
+from robotiq_3f_gripper_control.msg import _Robotiq3FGripper_robot_output as outputMsg
 
 
 def mainLoop(device):
-    # Gripper is a S-Model with a TCP connection
-    gripper = robotiq_s_model_control.baseSModel.robotiqBaseSModel()
+    # Gripper is a 3F gripper with a TCP connection
+    gripper = robotiq_3f_gripper_control.baseRobotiq3FGripper.robotiqbaseRobotiq3FGripper()
     gripper.client = robotiq_modbus_rtu.comModbusRtu.communication(retry=True)
 
     # We connect to the address received as an argument
     gripper.client.connectToDevice(device)
 
-    rospy.init_node('robotiqSModel')
+    rospy.init_node('robotiq3FGripper')
 
-    # The Gripper status is published on the topic named 'SModelRobotInput'
-    pub = rospy.Publisher('SModelRobotInput', inputMsg.SModel_robot_input, queue_size=1)
+    # The Gripper status is published on the topic named 'Robotiq3FGripperRobotInput'
+    pub = rospy.Publisher('Robotiq3FGripperRobotInput', inputMsg.Robotiq3FGripper_robot_input, queue_size=1)
 
-    # The Gripper command is received from the topic named 'SModelRobotOutput'
-    rospy.Subscriber('SModelRobotOutput', outputMsg.SModel_robot_output, gripper.refreshCommand)
+    # The Gripper command is received from the topic named 'Robotiq3FGripperRobotOutput'
+    rospy.Subscriber('Robotiq3FGripperRobotOutput', outputMsg.Robotiq3FGripper_robot_output, gripper.refreshCommand)
 
     # We loop
     while not rospy.is_shutdown():

--- a/robotiq_3f_gripper_control/nodes/Robotiq3FGripperRtuNode.py
+++ b/robotiq_3f_gripper_control/nodes/Robotiq3FGripperRtuNode.py
@@ -51,13 +51,7 @@ def mainLoop(device):
 
 if __name__ == '__main__':
     try:
-        # TODO: Add verification that the argument is an IP address
+        # TODO: Add verification that the argument is a valid device
         mainLoop(sys.argv[1])
     except rospy.ROSInterruptException:
         pass
-
-if __name__ == '__main__':
-    try:
-        # TODO: Add verification that the argument is a valid device
-        mainLoop(sys.argv[1])
-    except rospy.ROSInterruptException: pass

--- a/robotiq_ft_sensor/src/rq_sensor_com.cpp
+++ b/robotiq_ft_sensor/src/rq_sensor_com.cpp
@@ -1183,6 +1183,7 @@ static UINT_8 rq_com_identify_device(INT_8 const * const d_name)
 	strcat(dirParent, d_name);
 	strcpy(port_com, dirParent);
 	fd_connexion = open(port_com, O_RDWR | O_NOCTTY | O_NDELAY | O_EXCL);
+	usleep(1000000);
 
     //The serial port is open
     if (fd_connexion != -1)

--- a/robotiq_ft_sensor/src/rq_sensor_com.cpp
+++ b/robotiq_ft_sensor/src/rq_sensor_com.cpp
@@ -170,7 +170,8 @@ INT_8 rq_sensor_com()
     {
         //Look for a serial device
         if (strstr(entrydirectory->d_name, "ttyS") ||
-            strstr(entrydirectory->d_name, "ttyUSB"))
+            strstr(entrydirectory->d_name, "ttyUSB") ||
+            strstr(entrydirectory->d_name, "rfcomm"))
         {
             device_found = rq_com_identify_device(entrydirectory->d_name);
         }

--- a/robotiq_ft_sensor/src/rq_sensor_state.cpp
+++ b/robotiq_ft_sensor/src/rq_sensor_state.cpp
@@ -73,10 +73,16 @@ INT_8 rq_sensor_state(unsigned int max_retries, const std::string& ftdi_id)
 	switch (current_state)
 	{
 	case RQ_STATE_INIT:
+	    //first make sure there is no stream running
+	    rq_com_listen_stream();
+            if(rq_com_get_valid_stream() == true){
+                current_state = RQ_STATE_RUN;
+            }
+
 		ret = rq_state_init_com(ftdi_id);
 		if(ret == -1)
 		{
-            return -1;
+                    return -1;
 		}
 		break;
 

--- a/robotiq_modbus_rtu/src/robotiq_modbus_rtu/comModbusRtu.py
+++ b/robotiq_modbus_rtu/src/robotiq_modbus_rtu/comModbusRtu.py
@@ -44,6 +44,8 @@ The module depends on pymodbus (http://code.google.com/p/pymodbus/) for the Modb
 """
 
 from pymodbus.client.sync import ModbusSerialClient
+from pymodbus.register_read_message import ReadHoldingRegistersResponse
+from pymodbus.register_write_message import WriteMultipleRegistersResponse
 from math import ceil
 
 class communication:	
@@ -81,7 +83,7 @@ class communication:
       if self.retry:
          while True:
             response = self.client.write_registers(0x03E8, message, unit=0x0009)
-            if response:
+            if isinstance(response, WriteMultipleRegistersResponse):
                break
       else:
          # To do!: Implement try/except
@@ -95,7 +97,7 @@ class communication:
       if self.retry:
          while True:
             response = self.client.read_holding_registers(0x07D0, numRegs, unit=0x0009)
-            if response:
+            if isinstance(response, ReadHoldingRegistersResponse):
                break
       else:
          # To do!: Implement try/except

--- a/robotiq_s_model_control/nodes/SModelRtuNode.py
+++ b/robotiq_s_model_control/nodes/SModelRtuNode.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+"""@package docstring
+ROS node for controling a Robotiq S-Model gripper using the Modbus RTU protocol.
+
+The script takes as an argument the device address of the gripper (e.g. /dev/ttyUSB0). Afterwards it acts like the
+SModelTcpNode.
+"""
+
+import roslib; roslib.load_manifest('robotiq_s_model_control')
+roslib.load_manifest('robotiq_modbus_tcp')
+import rospy
+import robotiq_s_model_control.baseSModel
+import robotiq_modbus_rtu.comModbusRtu
+import os, sys
+from robotiq_s_model_control.msg import _SModel_robot_input  as inputMsg
+from robotiq_s_model_control.msg import _SModel_robot_output as outputMsg
+
+
+def mainLoop(device):
+    # Gripper is a S-Model with a TCP connection
+    gripper = robotiq_s_model_control.baseSModel.robotiqBaseSModel()
+    gripper.client = robotiq_modbus_rtu.comModbusRtu.communication(retry=True)
+
+    # We connect to the address received as an argument
+    gripper.client.connectToDevice(device)
+
+    rospy.init_node('robotiqSModel')
+
+    # The Gripper status is published on the topic named 'SModelRobotInput'
+    pub = rospy.Publisher('SModelRobotInput', inputMsg.SModel_robot_input, queue_size=1)
+
+    # The Gripper command is received from the topic named 'SModelRobotOutput'
+    rospy.Subscriber('SModelRobotOutput', outputMsg.SModel_robot_output, gripper.refreshCommand)
+
+    # We loop
+    while not rospy.is_shutdown():
+        # Get and publish the Gripper status
+        status = gripper.getStatus()
+        pub.publish(status)
+
+        # Wait a little
+        rospy.sleep(0.05)
+
+        # Send the most recent command
+        gripper.sendCommand()
+
+        # Wait a little
+        rospy.sleep(0.05)
+
+
+if __name__ == '__main__':
+    try:
+        # TODO: Add verification that the argument is an IP address
+        mainLoop(sys.argv[1])
+    except rospy.ROSInterruptException:
+        pass
+
+if __name__ == '__main__':
+    try:
+        # TODO: Add verification that the argument is a valid device
+        mainLoop(sys.argv[1])
+    except rospy.ROSInterruptException: pass


### PR DESCRIPTION
This is an upgraded version of PR https://github.com/ros-industrial/robotiq/pull/109 from @SammyRamone.

It enables connecting the Robotiq gripper and FT sensor via Bluetooth, as described [here](https://github.com/TAMS-Group/tams_robotiq_bluetooth).
The changes are rebased to kinetic-devel and comply with the new identifier names  (PR https://github.com/ros-industrial/robotiq/pull/130, https://github.com/ros-industrial/robotiq/commit/2f12788b01885050f8875f86e2d3a91223c13b88).

