### PR TITLE
Add pre-release builds and update README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ env:
   matrix:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic" PRERELEASE=true
+    - ROS_DISTRO="melodic" PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic" PRERELEASE=true
+    - env: ROS_DISTRO="melodic" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 ## ROS Distro Support
 
-|         | Indigo | Jade | Kinetic |
-|:-------:|:------:|:----:|:-------:|
-| Branch  | [`indigo-devel`](https://github.com/ros-industrial/robotiq/tree/indigo-devel) | [`indigo-devel`](https://github.com/ros-industrial/robotiq/tree/indigo-devel) | [`jade-devel`](https://github.com/ros-industrial/robotiq/tree/jade-devel) |
-| Status  |  supported | not supported |  supported |
-| Version | [version](http://repositories.ros.org/status_page/ros_indigo_default.html?q=robotiq) | [version](http://repositories.ros.org/status_page/ros_jade_default.html?q=robotiq) | [version](http://repositories.ros.org/status_page/ros_kinetic_default.html?q=robotiq) |
+|         | Indigo | Jade | Kinetic | Melodic |
+|:-------:|:------:|:----:|:-------:|:-------:|
+| Branch  | [`indigo-devel`](https://github.com/ros-industrial/robotiq/tree/indigo-devel) | [`jade-devel`](https://github.com/ros-industrial/robotiq/tree/jade-devel) | [`kinetic-devel`](https://github.com/ros-industrial/robotiq/tree/kinetic-devel) | [`kinetic-devel`](https://github.com/ros-industrial/robotiq/tree/kinetic-devel) |)
+| Status  |  supported | not supported |  supported |  supported |
+| Version | [version](http://repositories.ros.org/status_page/ros_indigo_default.html?q=robotiq) | [version](http://repositories.ros.org/status_page/ros_jade_default.html?q=robotiq) | [version](http://repositories.ros.org/status_page/ros_kinetic_default.html?q=robotiq) | [version](http://repositories.ros.org/status_page/ros_melodic_default.html?q=robotiq) |
 
 ## Travis - Continuous Integration
 
-Status: [![Build Status](https://travis-ci.org/ros-industrial/robotiq.svg?branch=jade-devel)](https://travis-ci.org/ros-industrial/robotiq)
+Status: [![Build Status](https://travis-ci.org/ros-industrial/robotiq.svg?branch=kinetic-devel)](https://travis-ci.org/ros-industrial/robotiq)
 
 ## ROS Buildfarm
 
-|         | Indigo Source | Indigo Debian | Jade Source | Jade Debian |  Kinetic Source  |  Kinetic Debian |
+|         | Indigo Source | Indigo Debian | Kinetic Source | Kinetic Debian |  Melodic Source  |  Melodic Debian |
 |:-------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
-| robotiq | [![not released](http://build.ros.org/buildStatus/icon?job=Isrc_uT__robotiq__ubuntu_trusty__source)](http://build.ros.org/view/Isrc_uT/job/Isrc_uT__robotiq__ubuntu_trusty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Ibin_uT64__robotiq__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__robotiq__ubuntu_trusty_amd64__binary/) | [![not released](http://build.ros.org/buildStatus/icon?job=Jsrc_uT__robotiq__ubuntu_trusty__source)](http://build.ros.org/view/Jsrc_uT/job/Jsrc_uT__robotiq__ubuntu_trusty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Jbin_uT64__robotiq__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Jbin_uT64/job/Jbin_uT64__robotiq__ubuntu_trusty_amd64__binary/) | [![not released](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__robotiq__ubuntu_xenial__source)](http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__robotiq__ubuntu_xenial__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__robotiq__ubuntu_xenial_amd64__binary)](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__robotiq__ubuntu_xenial_amd64__binary/) |
+| robotiq | [![not released](http://build.ros.org/buildStatus/icon?job=Isrc_uT__robotiq__ubuntu_trusty__source)](http://build.ros.org/view/Isrc_uT/job/Isrc_uT__robotiq__ubuntu_trusty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Ibin_uT64__robotiq__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__robotiq__ubuntu_trusty_amd64__binary/) | [![not released](http://build.ros.org/buildStatus/icon?job=Jsrc_uT__robotiq__ubuntu_trusty__source)](http://build.ros.org/view/Jsrc_uT/job/Jsrc_uT__robotiq__ubuntu_trusty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Jbin_uT64__robotiq__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Jbin_uT64/job/Jbin_uT64__robotiq__ubuntu_trusty_amd64__binary/) | [![not released](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__robotiq__ubuntu_xenial__source)](http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__robotiq__ubuntu_xenial__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__robotiq__ubuntu_xenial_amd64__binary)](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__robotiq__ubuntu_xenial_amd64__binary/) | | [![not released](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__robotiq__ubuntu_bounty__source)](http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__robotiq__ubuntu_bounty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__robotiq__ubuntu_bounty_amd64__binary)](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__robotiq__ubuntu_bounty_amd64__binary/) |
 
 [![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 


### PR DESCRIPTION
Adds pre-release builds to travis to check whether all dependencies for a release are met. Also updates the README with branch information (I believe Jade should be `jade-devel` and both Kinetic and Melodic will be `kinetic-devel`). 

cc @jproberge 