### PR TITLE
fix mimic joint limits

### DIFF
--- a/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
+++ b/robotiq_2f_140_gripper_visualization/urdf/robotiq_arg2f_140_model_macro.xacro
@@ -165,7 +165,7 @@
       <parent link="${prefix}robotiq_arg2f_base_link" />
       <child link="${prefix}${fingerprefix}_inner_knuckle" />
       <axis xyz="1 0 0" />
-      <limit lower="0" upper="0.8757" velocity="2.0" effort="1000" />
+      <limit lower="-0.8757" upper="0.8757" velocity="2.0" effort="1000" />
       <mimic joint="${prefix}finger_joint" multiplier="-1" offset="0" />
     </joint>
   </xacro:macro>
@@ -176,7 +176,7 @@
       <parent link="${prefix}${fingerprefix}_outer_finger" />
       <child link="${prefix}${fingerprefix}_inner_finger" />
       <axis xyz="1 0 0" />
-      <limit lower="0" upper="0.8757" velocity="2.0" effort="1000" />
+      <limit lower="-0.8757" upper="0.8757" velocity="2.0" effort="1000" />
       <mimic joint="${prefix}finger_joint" multiplier="1" offset="0" />
     </joint>
   </xacro:macro>
@@ -209,7 +209,7 @@
       <parent link="${prefix}robotiq_arg2f_base_link" />
       <child link="${prefix}right_outer_knuckle" />
       <axis xyz="1 0 0" />
-      <limit lower="0" upper="0.725" velocity="2.0" effort="1000" />
+      <limit lower="-0.725" upper="0.725" velocity="2.0" effort="1000" />
     <mimic joint="${prefix}finger_joint" multiplier="-1" offset="0" />
     </joint>
     <xacro:finger_joints prefix="${prefix}" fingerprefix="right" reflect="-1.0"/>


### PR DESCRIPTION
Hi,
I'm using gazebo to simulate robotiq_2f_140_gripper with the [MimicJointPlugin](https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins). Some problems occurred. Then I found that the mimic joint limits were wrong. For example, the limits of left_inner_knuckle_joint and right_inner_knuckle_joint should be [-0.8757, 0] and [0, 0.8757], but they were both set as [0, 0.8757]. Since they are mimic joints, I think the simplest solution is to set the joint limits symmetrically.