### PR TITLE
robotiq_ft_sensor: read symlink of sensor file descriptor

### DIFF
--- a/robotiq_ft_sensor/nodes/rq_sensor.cpp
+++ b/robotiq_ft_sensor/nodes/rq_sensor.cpp
@@ -203,6 +203,22 @@ int main(int argc, char **argv)
     {
         ROS_INFO("No device filename specified. Will attempt to discover Robotiq force torque sensor.");
     }
+    // read symlink
+    if (!ftdi_id.empty())
+    {
+      char ftdi_id_buf[512];
+      size_t count = readlink(("/dev/" + ftdi_id).c_str(), ftdi_id_buf, sizeof(ftdi_id_buf));
+      if (count > 0)
+      {
+        ftdi_id_buf[count] = '\0';
+        ftdi_id = std::string(ftdi_id_buf);
+      }
+      else
+      {
+        ROS_FATAL("cannot read file descriptor at /dev/%s", ftdi_id.c_str());
+        return 1;
+      }
+    }
 
 	INT_8 bufStream[512];
         robotiq_ft_sensor::ft_sensor msgStream;


### PR DESCRIPTION
The current node crushes if given `serial_id` points out symlink.
For example, if `/dev/ttyUSB0` is symlinked to `/dev/robotiq_ft_sensor` by `udev`, the error shows up as followings:

```
$ rosrun robotiqt_sensor rq_sensor _serial_id:=rarm_robotiq_ft_sensor
[ INFO] [1562236271.820355094] [/robotiq_ft_sensor:ros.robotiq_ft_sensor]: Trying to connect to a sensor at /dev/rarm_robotiq_ft_sensor
*** buffer overflow detected ***: ~/catkin_ws/devel/lib/robotiq_ft_sensor/rq_sensor terminated
... a lot of core dumps ...
```

This PR fixes the error by reading symlinks before passing it to the part of sensor reading.