### PR TITLE
Fix path to soem headers

### DIFF
--- a/robotiq_ethercat/src/ethercat_manager.cpp
+++ b/robotiq_ethercat/src/ethercat_manager.cpp
@@ -7,15 +7,15 @@
 #include <boost/ref.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 
-#include <soem/ethercattype.h>
-#include <soem/nicdrv.h>
-#include <soem/ethercatbase.h>
-#include <soem/ethercatmain.h>
-#include <soem/ethercatdc.h>
-#include <soem/ethercatcoe.h>
-#include <soem/ethercatfoe.h>
-#include <soem/ethercatconfig.h>
-#include <soem/ethercatprint.h>
+#include <ethercattype.h>
+#include <nicdrv.h>
+#include <ethercatbase.h>
+#include <ethercatmain.h>
+#include <ethercatdc.h>
+#include <ethercatcoe.h>
+#include <ethercatfoe.h>
+#include <ethercatconfig.h>
+#include <ethercatprint.h>
 
 #include <ros/ros.h>
 


### PR DESCRIPTION
This change is required In order to compile robotiq_ethercat package with soem source code.
soem package provides include path with [soem prefix](https://github.com/mgruhler/soem/blob/master/CMakeLists.txt#L32) and 'soem/' prefix in include macro is not required.

If ros-kinetic-soem apt package is installed instead of building with source code, wrong include path to soem headers does not cause any error because `/opt/ros/kinetic/include` is provided by catkin_INCLUDE_DIRS.


