### PR TITLE
Fix deprecated xacro syntax without namespace prefix

### DIFF
--- a/robotiq_3f_gripper_visualization/cfg/robotiq_hand_macro.urdf.xacro
+++ b/robotiq_3f_gripper_visualization/cfg/robotiq_hand_macro.urdf.xacro
@@ -695,7 +695,7 @@ there are multiple hands then a prefix followed by an "_" is needed.
 
     <!-- joint attaching parent link to robotiq hand -->
     <joint name="${prefix}robotiq_hand_joint" type="fixed">
-      <insert_block name="origin"/>
+      <xacro:insert_block name="origin"/>
       <parent link="${parent}"/>
       <child link="${prefix}palm"/>
     </joint>

--- a/robotiq_ft_sensor/urdf/robotiq_ft300.urdf.xacro
+++ b/robotiq_ft_sensor/urdf/robotiq_ft300.urdf.xacro
@@ -21,7 +21,7 @@
 
         <!-- mount the fts to the robot -->
         <joint name="${prefix}ft300_fix" type="fixed">
-            <insert_block name="origin" />
+            <xacro:insert_block name="origin" />
             <parent link="${parent}" />
             <child link="${prefix}ft300_mounting_plate" />
         </joint>

--- a/robotiq_ft_sensor/urdf/robotiq_fts150.urdf.xacro
+++ b/robotiq_ft_sensor/urdf/robotiq_fts150.urdf.xacro
@@ -6,7 +6,7 @@
         <!-- mount the fts to the robot -->
         <joint name="${prefix}fts_fix" type="fixed" >
             <!--In most cases origin would be flange adapter plate: <origin xyz="0 0 0.009" rpy="0 0 0"/> /-->
-            <insert_block name="origin" />
+            <xacro:insert_block name="origin" />
             <parent link="${parent}" />
             <child link="${prefix}fts_robotside" />
         </joint>


### PR DESCRIPTION
I use the Robotiq FT sensor package and was quite irritated to see this warning all the time:

> deprecated: xacro tags should be prepended with 'xacro' xml namespace.

As written in the warning and also in the [ROS Wiki](http://wiki.ros.org/xacro#Deprecated_Syntax) it is deprecated since ROS Jade to use Xacro tags without a namespace. Most of the xacro files are fine, but a few ones trigger this warning. This PR is fixing this, would be glad to see it upstream.