### PR TITLE
Feature: Loads controller for Gazebo and allows to use prefixes.

### DIFF
--- a/robotiq_3f_gripper_articulated_gazebo_plugins/include/robotiq_3f_gripper_articulated_gazebo_plugins/RobotiqHandPlugin.h
+++ b/robotiq_3f_gripper_articulated_gazebo_plugins/include/robotiq_3f_gripper_articulated_gazebo_plugins/RobotiqHandPlugin.h
@@ -37,8 +37,8 @@
 
 /// \brief A plugin that implements the Robotiq 3-Finger Adaptative Gripper.
 /// The plugin exposes the next parameters via SDF tags:
-///   * <side> Determines if we are controlling the left or right hand. This is
-///            a required parameter and the allowed values are 'left' or 'right'
+///   * <prefix> Defines a prefix that is used for the joints and the topics. 
+///              This parameter is optional.
 ///   * <kp_position> P gain for the PID that controls the position
 ///                   of the joints. This parameter is optional.
 ///   * <ki_position> I gain for the PID that controls the position
@@ -186,18 +186,6 @@ class RobotiqHandPlugin : public gazebo::ModelPlugin
   /// \brief Max. joint speed (rad/s). Finger is 125mm and tip speed is 110mm/s.
   private: static constexpr double MaxVelocity = 0.88;
 
-  /// \brief Default topic name for sending control updates to the left hand.
-  private: static const std::string DefaultLeftTopicCommand;
-
-  /// \brief Default topic name for receiving state updates from the left hand.
-  private: static const std::string DefaultLeftTopicState;
-
-  /// \brief Default topic name for sending control updates to the right hand.
-  private: static const std::string DefaultRightTopicCommand;
-
-  /// \brief Default topic name for receiving state updates from the right hand.
-  private: static const std::string DefaultRightTopicState;
-
   /// \brief ROS NodeHandle.
   private: boost::scoped_ptr<ros::NodeHandle> rosNode;
 
@@ -271,8 +259,14 @@ class RobotiqHandPlugin : public gazebo::ModelPlugin
   /// \brief Pointer to the SDF of this plugin.
   private: sdf::ElementPtr sdf;
 
-  /// \brief Used to select between 'left' or 'right' hand.
-  private: std::string side;
+  /// \brief Used to select a prefix for the hand.
+  private: std::string prefix;
+
+  /// \brief Topic name for sending control updates to the hand.
+  private: std::string topicCommand;
+
+  /// \brief Topic name for receiving state updates from the hand.
+  private: std::string topicState;
 
   /// \brief Vector containing all the joint names.
   private: std::vector<std::string> jointNames;

--- a/robotiq_3f_gripper_visualization/cfg/robotiq-3f-gripper_actuated_gazebo.xacro
+++ b/robotiq_3f_gripper_visualization/cfg/robotiq-3f-gripper_actuated_gazebo.xacro
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<!-- 
+robotiq-3f-gripper_actuated_gazebo - actuated version of the robotiq robotiq-3f-gripper, 3 fingered gripper.
+-->
+<robot name="robotiq-3f-gripper_actuated_gazebo" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:include filename="$(find robotiq_3f_gripper_visualization)/cfg/robotiq_hand_macro.urdf.xacro" />
+
+    <link name="world"/>
+
+    <robotiq_hand prefix="" parent="world" reflect="">
+      <origin xyz="0 0 0.5" rpy="0 0 0"/>
+    </robotiq_hand>
+
+  <gazebo>
+    <!-- plugin for the RobotiQ hand -->
+    <plugin name="robotiq_hand_plugin" filename="libRobotiqHandPlugin.so">
+      <kp_position>10.0</kp_position>
+      <kd_position>0.5</kd_position>
+      <!-- Some optional parameters. Check the plugin header file for all of them. -->
+      <!--<prefix>pre_</prefix>-->
+      <!-- This is chosen, so it's compatible with the "Robotiq3FGripperSimpleController.py"-->
+      <topic_command>/Robotiq3FGripperRobotOutput</topic_command>
+      <!-- <topic_state>/hand/state</topic_state> -->
+
+    </plugin>
+  </gazebo>
+</robot>
+

--- a/robotiq_3f_gripper_visualization/launch/robotiq_gripper_upload.launch
+++ b/robotiq_3f_gripper_visualization/launch/robotiq_gripper_upload.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-   <param name="robot_description" command="$(find xacro)/xacro.py '$(find robotiq_3f_gripper_visualization)/cfg/robotiq-3f-gripper_articulated.xacro'" />
+   <param name="robot_description" command="$(find xacro)/xacro.py '$(find robotiq_3f_gripper_visualization)/cfg/robotiq-3f-gripper_actuated_gazebo.xacro'" />
  </launch>


### PR DESCRIPTION
- Introduces a xacro file that loads the Gazebo control plugin.
- This enables to control the gripper in Gazebo, e.g. with the
"Robotiq3FGripperSimpleController.py".
- Removes the "side" parameter and replaces it with an optional
"prefix" parameter that allows to use arbitrary names.