### PR TITLE
[robotiq_ft_sensor] Delete _gencfg dependency

### DIFF
--- a/robotiq_ft_sensor/CMakeLists.txt
+++ b/robotiq_ft_sensor/CMakeLists.txt
@@ -47,11 +47,11 @@ include_directories(
 
 # make the executables
 add_executable(rq_sensor nodes/rq_sensor.cpp src/rq_sensor_com.cpp src/rq_sensor_state.cpp)
-add_dependencies(rq_sensor ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_gencpp)
+add_dependencies(rq_sensor ${catkin_EXPORTED_TARGETS})
 target_link_libraries(rq_sensor ${catkin_LIBRARIES})
-
+ 
 add_executable(rq_test_sensor nodes/rq_test_sensor.cpp)
-add_dependencies(rq_test_sensor ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_gencpp)
+add_dependencies(rq_test_sensor ${catkin_EXPORTED_TARGETS})
 target_link_libraries(rq_test_sensor ${catkin_LIBRARIES})
 
 install(TARGETS rq_sensor rq_test_sensor


### PR DESCRIPTION
Currently, when building robotiq_ft_sensor, the following errors occur.
```
CMake Error at CMakeLists.txt:50 (add_dependencies):
  The dependency target "robotiq_ft_sensor_gencfg" of target "rq_sensor" does
  not exist.


CMake Error at CMakeLists.txt:54 (add_dependencies):
  The dependency target "robotiq_ft_sensor_gencfg" of target "rq_test_sensor"
  does not exist.
```
This package seems not to use `dynamic_reconfigure`, so `*_gencfg` are not needed.

This PR delete the dependency of "robotiq_ft_sensor_gencfg" to succeed in building the package.

If you/users want to use dynamic_reconfigure, you should add `<depend>dynamic_reconfigure</depend>` in stead of deleting this dependency.